### PR TITLE
Feature to allow custom verify providers for individual authentication context

### DIFF
--- a/src/decorators/authenticate-user.decorator.ts
+++ b/src/decorators/authenticate-user.decorator.ts
@@ -1,12 +1,14 @@
 import {
+  BindingKey,
   Constructor,
   MetadataInspector,
   MethodDecoratorFactory,
 } from '@loopback/context';
-import {Request} from '@loopback/rest';
+import { Request } from '@loopback/rest';
 
-import {USER_AUTHENTICATION_METADATA_KEY} from '../keys';
-import {AuthenticationMetadata} from '../types';
+import { USER_AUTHENTICATION_METADATA_KEY } from '../keys';
+import { VerifyFunction } from '../strategies';
+import { AuthenticationMetadata } from '../types';
 
 /**
  * `@authenticate` decorator for adding authentication to controller methods
@@ -15,6 +17,7 @@ import {AuthenticationMetadata} from '../types';
  * like `Strategy.LOCAL`
  * @param options       Extra options to be passed on
  * while instantiating strategy specific class
+ * @param verifier    Binding key for a custom verifier
  * @param authOptions   Extra options to be passed on to `authenticate` method
  * of the strategy.
  * This is a creator function which should return an object with options.
@@ -25,6 +28,7 @@ import {AuthenticationMetadata} from '../types';
 export function authenticate(
   strategyName: string,
   options?: Object,
+  verifier?: BindingKey<VerifyFunction.GenericAuthFn>,
   authOptions?: (req: Request) => Object,
 ) {
   return MethodDecoratorFactory.createDecorator<AuthenticationMetadata>(
@@ -32,6 +36,7 @@ export function authenticate(
     {
       strategy: strategyName,
       options: options ?? {},
+      verifier,
       authOptions: authOptions,
     },
   );

--- a/src/decorators/authenticate-user.decorator.ts
+++ b/src/decorators/authenticate-user.decorator.ts
@@ -4,11 +4,11 @@ import {
   MetadataInspector,
   MethodDecoratorFactory,
 } from '@loopback/context';
-import {Request} from '@loopback/rest';
+import { Request } from '@loopback/rest';
 
-import {USER_AUTHENTICATION_METADATA_KEY} from '../keys';
-import {VerifyFunction} from '../strategies';
-import {AuthenticationMetadata} from '../types';
+import { USER_AUTHENTICATION_METADATA_KEY } from '../keys';
+import { VerifyFunction } from '../strategies';
+import { AuthenticationMetadata } from '../types';
 
 /**
  * `@authenticate` decorator for adding authentication to controller methods
@@ -28,16 +28,16 @@ import {AuthenticationMetadata} from '../types';
 export function authenticate(
   strategyName: string,
   options?: Object,
-  verifier?: BindingKey<VerifyFunction.GenericAuthFn>,
   authOptions?: (req: Request) => Object,
+  verifier?: BindingKey<VerifyFunction.GenericAuthFn>,
 ) {
   return MethodDecoratorFactory.createDecorator<AuthenticationMetadata>(
     USER_AUTHENTICATION_METADATA_KEY,
     {
       strategy: strategyName,
       options: options ?? {},
-      verifier,
       authOptions: authOptions,
+      verifier,
     },
   );
 }

--- a/src/decorators/authenticate-user.decorator.ts
+++ b/src/decorators/authenticate-user.decorator.ts
@@ -4,11 +4,11 @@ import {
   MetadataInspector,
   MethodDecoratorFactory,
 } from '@loopback/context';
-import { Request } from '@loopback/rest';
+import {Request} from '@loopback/rest';
 
-import { USER_AUTHENTICATION_METADATA_KEY } from '../keys';
-import { VerifyFunction } from '../strategies';
-import { AuthenticationMetadata } from '../types';
+import {USER_AUTHENTICATION_METADATA_KEY} from '../keys';
+import {VerifyFunction} from '../strategies';
+import {AuthenticationMetadata} from '../types';
 
 /**
  * `@authenticate` decorator for adding authentication to controller methods

--- a/src/strategies/passport/passport-azure-ad/azuread-auth-strategy-factory-provider.ts
+++ b/src/strategies/passport/passport-azure-ad/azuread-auth-strategy-factory-provider.ts
@@ -1,9 +1,9 @@
-import { inject, Provider } from '@loopback/core';
-import { HttpErrors, Request } from '@loopback/rest';
+import {inject, Provider} from '@loopback/core';
+import {HttpErrors, Request} from '@loopback/rest';
 
-import { AuthErrorKeys } from '../../../error-keys';
-import { Strategies } from '../../keys';
-import { VerifyFunction } from '../../types';
+import {AuthErrorKeys} from '../../../error-keys';
+import {Strategies} from '../../keys';
+import {VerifyFunction} from '../../types';
 import {
   IProfile,
   VerifyCallback,
@@ -15,7 +15,7 @@ import {
 export interface AzureADAuthStrategyFactory {
   (
     options: IOIDCStrategyOptionWithoutRequest | IOIDCStrategyOptionWithRequest,
-    verifierPassed?: VerifyFunction.AzureADAuthFn
+    verifierPassed?: VerifyFunction.AzureADAuthFn,
   ): OIDCStrategy;
 }
 
@@ -24,15 +24,16 @@ export class AzureADAuthStrategyFactoryProvider
   constructor(
     @inject(Strategies.Passport.AZURE_AD_VERIFIER)
     private readonly verifierAzureADAuth: VerifyFunction.AzureADAuthFn,
-  ) { }
+  ) {}
 
   value(): AzureADAuthStrategyFactory {
-    return (options, verifier) => this.getAzureADAuthStrategyVerifier(options, verifier);
+    return (options, verifier) =>
+      this.getAzureADAuthStrategyVerifier(options, verifier);
   }
 
   getAzureADAuthStrategyVerifier(
     options: IOIDCStrategyOptionWithoutRequest | IOIDCStrategyOptionWithRequest,
-    verifierPassed?: VerifyFunction.AzureADAuthFn
+    verifierPassed?: VerifyFunction.AzureADAuthFn,
   ): OIDCStrategy {
     const verifyFn = verifierPassed ?? this.verifierAzureADAuth;
     if (options && options.passReqToCallback === true) {

--- a/src/strategies/passport/passport-bearer/bearer-strategy-factory-provider.ts
+++ b/src/strategies/passport/passport-bearer/bearer-strategy-factory-provider.ts
@@ -1,15 +1,18 @@
-import { inject, Provider } from '@loopback/core';
-import { HttpErrors, Request } from '@loopback/rest';
+import {inject, Provider} from '@loopback/core';
+import {HttpErrors, Request} from '@loopback/rest';
 import * as PassportBearer from 'passport-http-bearer';
 
-import { AuthErrorKeys } from '../../../error-keys';
-import { IAuthUser } from '../../../types';
-import { Strategies } from '../../keys';
-import { VerifyFunction } from '../../types';
-import { isEmpty } from 'lodash';
+import {AuthErrorKeys} from '../../../error-keys';
+import {IAuthUser} from '../../../types';
+import {Strategies} from '../../keys';
+import {VerifyFunction} from '../../types';
+import {isEmpty} from 'lodash';
 
 export interface BearerStrategyFactory {
-  (options?: PassportBearer.IStrategyOptions, verifierPassed?: VerifyFunction.BearerFn): PassportBearer.Strategy;
+  (
+    options?: PassportBearer.IStrategyOptions,
+    verifierPassed?: VerifyFunction.BearerFn,
+  ): PassportBearer.Strategy;
 }
 
 export class BearerStrategyFactoryProvider
@@ -17,15 +20,16 @@ export class BearerStrategyFactoryProvider
   constructor(
     @inject(Strategies.Passport.BEARER_TOKEN_VERIFIER)
     private readonly verifierBearer: VerifyFunction.BearerFn,
-  ) { }
+  ) {}
 
   value(): BearerStrategyFactory {
-    return (options, verifier) => this.getBearerStrategyVerifier(options, verifier);
+    return (options, verifier) =>
+      this.getBearerStrategyVerifier(options, verifier);
   }
 
   getBearerStrategyVerifier(
     options?: PassportBearer.IStrategyOptions,
-    verifierPassed?: VerifyFunction.BearerFn
+    verifierPassed?: VerifyFunction.BearerFn,
   ): PassportBearer.Strategy {
     const verifyFn = verifierPassed ?? this.verifierBearer;
     if (options?.passReqToCallback) {

--- a/src/strategies/passport/passport-bearer/bearer-token-verify.provider.ts
+++ b/src/strategies/passport/passport-bearer/bearer-token-verify.provider.ts
@@ -13,7 +13,7 @@ export class BearerTokenVerifyProvider
   constructor() {}
 
   value(): VerifyFunction.BearerFn {
-    return async (token) => {
+    return async (token: string) => {
       throw new HttpErrors.NotImplemented(
         `VerifyFunction.BearerFn is not implemented`,
       );

--- a/src/strategies/passport/passport-client-password/client-password-strategy-factory-provider.ts
+++ b/src/strategies/passport/passport-client-password/client-password-strategy-factory-provider.ts
@@ -1,16 +1,16 @@
-import { inject, Provider } from '@loopback/core';
-import { HttpErrors, Request } from '@loopback/rest';
+import {inject, Provider} from '@loopback/core';
+import {HttpErrors, Request} from '@loopback/rest';
 import * as ClientPasswordStrategy from 'passport-oauth2-client-password';
 
-import { AuthErrorKeys } from '../../../error-keys';
-import { IAuthClient } from '../../../types';
-import { Strategies } from '../../keys';
-import { VerifyFunction } from '../../types';
+import {AuthErrorKeys} from '../../../error-keys';
+import {IAuthClient} from '../../../types';
+import {Strategies} from '../../keys';
+import {VerifyFunction} from '../../types';
 
 export interface ClientPasswordStrategyFactory {
   (
     options?: ClientPasswordStrategy.StrategyOptionsWithRequestInterface,
-    verifierPassed?: VerifyFunction.OauthClientPasswordFn
+    verifierPassed?: VerifyFunction.OauthClientPasswordFn,
   ): ClientPasswordStrategy.Strategy;
 }
 
@@ -19,15 +19,16 @@ export class ClientPasswordStrategyFactoryProvider
   constructor(
     @inject(Strategies.Passport.OAUTH2_CLIENT_PASSWORD_VERIFIER)
     private readonly verifier: VerifyFunction.OauthClientPasswordFn,
-  ) { }
+  ) {}
 
   value(): ClientPasswordStrategyFactory {
-    return (options, verifier) => this.getClientPasswordVerifier(options, verifier);
+    return (options, verifier) =>
+      this.getClientPasswordVerifier(options, verifier);
   }
 
   getClientPasswordVerifier(
     options?: ClientPasswordStrategy.StrategyOptionsWithRequestInterface,
-    verifierPassed?: VerifyFunction.OauthClientPasswordFn
+    verifierPassed?: VerifyFunction.OauthClientPasswordFn,
   ): ClientPasswordStrategy.Strategy {
     const verifyFn = verifierPassed ?? this.verifier;
     if (options?.passReqToCallback) {

--- a/src/strategies/passport/passport-client-password/client-password-verify.provider.ts
+++ b/src/strategies/passport/passport-client-password/client-password-verify.provider.ts
@@ -13,7 +13,7 @@ export class ClientPasswordVerifyProvider
   constructor() {}
 
   value(): VerifyFunction.OauthClientPasswordFn {
-    return async (clientId, clientSecret) => {
+    return async (clientId: string, clientSecret: string) => {
       throw new HttpErrors.NotImplemented(
         `VerifyFunction.OauthClientPasswordFn is not implemented`,
       );

--- a/src/strategies/passport/passport-google-oauth2/google-auth-strategy-factory-provider.ts
+++ b/src/strategies/passport/passport-google-oauth2/google-auth-strategy-factory-provider.ts
@@ -1,5 +1,5 @@
-import {inject, Provider} from '@loopback/core';
-import {HttpErrors, Request} from '@loopback/rest';
+import { inject, Provider } from '@loopback/core';
+import { HttpErrors, Request } from '@loopback/rest';
 
 //import * as GoogleStrategy from 'passport-google-oauth20';
 import {
@@ -9,12 +9,12 @@ import {
   Profile,
   VerifyCallback,
 } from 'passport-google-oauth20';
-import {AuthErrorKeys} from '../../../error-keys';
-import {Strategies} from '../../keys';
-import {VerifyFunction} from '../../types';
+import { AuthErrorKeys } from '../../../error-keys';
+import { Strategies } from '../../keys';
+import { VerifyFunction } from '../../types';
 
 export interface GoogleAuthStrategyFactory {
-  (options: StrategyOptions | StrategyOptionsWithRequest): Strategy;
+  (options: StrategyOptions | StrategyOptionsWithRequest, verifierPassed?: VerifyFunction.GoogleAuthFn): Strategy;
 }
 
 export class GoogleAuthStrategyFactoryProvider
@@ -22,15 +22,17 @@ export class GoogleAuthStrategyFactoryProvider
   constructor(
     @inject(Strategies.Passport.GOOGLE_OAUTH2_VERIFIER)
     private readonly verifierGoogleAuth: VerifyFunction.GoogleAuthFn,
-  ) {}
+  ) { }
 
   value(): GoogleAuthStrategyFactory {
-    return (options) => this.getGoogleAuthStrategyVerifier(options);
+    return (options, verifier) => this.getGoogleAuthStrategyVerifier(options, verifier);
   }
 
   getGoogleAuthStrategyVerifier(
     options: StrategyOptions | StrategyOptionsWithRequest,
+    verifierPassed?: VerifyFunction.GoogleAuthFn
   ): Strategy {
+    const verifyFn = verifierPassed ?? this.verifierGoogleAuth;
     if (options && options.passReqToCallback === true) {
       return new Strategy(
         options,
@@ -44,7 +46,7 @@ export class GoogleAuthStrategyFactoryProvider
           cb: VerifyCallback,
         ) => {
           try {
-            const user = await this.verifierGoogleAuth(
+            const user = await verifyFn(
               accessToken,
               refreshToken,
               profile,
@@ -73,7 +75,7 @@ export class GoogleAuthStrategyFactoryProvider
           cb: VerifyCallback,
         ) => {
           try {
-            const user = await this.verifierGoogleAuth(
+            const user = await verifyFn(
               accessToken,
               refreshToken,
               profile,

--- a/src/strategies/passport/passport-google-oauth2/google-auth-strategy-factory-provider.ts
+++ b/src/strategies/passport/passport-google-oauth2/google-auth-strategy-factory-provider.ts
@@ -1,5 +1,5 @@
-import { inject, Provider } from '@loopback/core';
-import { HttpErrors, Request } from '@loopback/rest';
+import {inject, Provider} from '@loopback/core';
+import {HttpErrors, Request} from '@loopback/rest';
 
 //import * as GoogleStrategy from 'passport-google-oauth20';
 import {
@@ -9,12 +9,15 @@ import {
   Profile,
   VerifyCallback,
 } from 'passport-google-oauth20';
-import { AuthErrorKeys } from '../../../error-keys';
-import { Strategies } from '../../keys';
-import { VerifyFunction } from '../../types';
+import {AuthErrorKeys} from '../../../error-keys';
+import {Strategies} from '../../keys';
+import {VerifyFunction} from '../../types';
 
 export interface GoogleAuthStrategyFactory {
-  (options: StrategyOptions | StrategyOptionsWithRequest, verifierPassed?: VerifyFunction.GoogleAuthFn): Strategy;
+  (
+    options: StrategyOptions | StrategyOptionsWithRequest,
+    verifierPassed?: VerifyFunction.GoogleAuthFn,
+  ): Strategy;
 }
 
 export class GoogleAuthStrategyFactoryProvider
@@ -22,15 +25,16 @@ export class GoogleAuthStrategyFactoryProvider
   constructor(
     @inject(Strategies.Passport.GOOGLE_OAUTH2_VERIFIER)
     private readonly verifierGoogleAuth: VerifyFunction.GoogleAuthFn,
-  ) { }
+  ) {}
 
   value(): GoogleAuthStrategyFactory {
-    return (options, verifier) => this.getGoogleAuthStrategyVerifier(options, verifier);
+    return (options, verifier) =>
+      this.getGoogleAuthStrategyVerifier(options, verifier);
   }
 
   getGoogleAuthStrategyVerifier(
     options: StrategyOptions | StrategyOptionsWithRequest,
-    verifierPassed?: VerifyFunction.GoogleAuthFn
+    verifierPassed?: VerifyFunction.GoogleAuthFn,
   ): Strategy {
     const verifyFn = verifierPassed ?? this.verifierGoogleAuth;
     if (options && options.passReqToCallback === true) {
@@ -75,12 +79,7 @@ export class GoogleAuthStrategyFactoryProvider
           cb: VerifyCallback,
         ) => {
           try {
-            const user = await verifyFn(
-              accessToken,
-              refreshToken,
-              profile,
-              cb,
-            );
+            const user = await verifyFn(accessToken, refreshToken, profile, cb);
             if (!user) {
               throw new HttpErrors.Unauthorized(
                 AuthErrorKeys.InvalidCredentials,

--- a/src/strategies/passport/passport-keycloak/keycloak-strategy-factory-provider.ts
+++ b/src/strategies/passport/passport-keycloak/keycloak-strategy-factory-provider.ts
@@ -1,16 +1,19 @@
-import { inject, Provider } from '@loopback/core';
-import { HttpErrors } from '@loopback/rest';
+import {inject, Provider} from '@loopback/core';
+import {HttpErrors} from '@loopback/rest';
 
-import { AuthErrorKeys } from '../../../error-keys';
-import { IAuthUser } from '../../../types';
-import { Strategies } from '../../keys';
-import { KeycloakProfile, VerifyFunction } from '../../types';
+import {AuthErrorKeys} from '../../../error-keys';
+import {IAuthUser} from '../../../types';
+import {Strategies} from '../../keys';
+import {KeycloakProfile, VerifyFunction} from '../../types';
 
 export const KeycloakStrategy = require('@exlinc/keycloak-passport');
 
 export interface KeycloakStrategyFactory {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (options: any, verifierPassed?: VerifyFunction.KeycloakAuthFn): typeof KeycloakStrategy;
+  (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    options: any,
+    verifierPassed?: VerifyFunction.KeycloakAuthFn,
+  ): typeof KeycloakStrategy;
 }
 
 export class KeycloakStrategyFactoryProvider
@@ -18,14 +21,18 @@ export class KeycloakStrategyFactoryProvider
   constructor(
     @inject(Strategies.Passport.KEYCLOAK_VERIFIER)
     private readonly verifierKeycloak: VerifyFunction.KeycloakAuthFn,
-  ) { }
+  ) {}
 
   value(): KeycloakStrategyFactory {
-    return (options, verifier) => this.getKeycloakAuthStrategyVerifier(options, verifier);
+    return (options, verifier) =>
+      this.getKeycloakAuthStrategyVerifier(options, verifier);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getKeycloakAuthStrategyVerifier(options: any, verifierPassed?: VerifyFunction.KeycloakAuthFn): typeof KeycloakStrategy {
+  getKeycloakAuthStrategyVerifier(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    options: any,
+    verifierPassed?: VerifyFunction.KeycloakAuthFn,
+  ): typeof KeycloakStrategy {
     const verifyFn = verifierPassed ?? this.verifierKeycloak;
     return new KeycloakStrategy(
       options,
@@ -36,12 +43,7 @@ export class KeycloakStrategyFactoryProvider
         cb: (err?: string | Error, user?: IAuthUser) => void,
       ) => {
         try {
-          const user = await verifyFn(
-            accessToken,
-            refreshToken,
-            profile,
-            cb,
-          );
+          const user = await verifyFn(accessToken, refreshToken, profile, cb);
           if (!user) {
             throw new HttpErrors.Unauthorized(AuthErrorKeys.InvalidCredentials);
           }

--- a/src/strategies/passport/passport-keycloak/keycloak-strategy-factory-provider.ts
+++ b/src/strategies/passport/passport-keycloak/keycloak-strategy-factory-provider.ts
@@ -1,16 +1,16 @@
-import {inject, Provider} from '@loopback/core';
-import {HttpErrors} from '@loopback/rest';
+import { inject, Provider } from '@loopback/core';
+import { HttpErrors } from '@loopback/rest';
 
-import {AuthErrorKeys} from '../../../error-keys';
-import {IAuthUser} from '../../../types';
-import {Strategies} from '../../keys';
-import {KeycloakProfile, VerifyFunction} from '../../types';
+import { AuthErrorKeys } from '../../../error-keys';
+import { IAuthUser } from '../../../types';
+import { Strategies } from '../../keys';
+import { KeycloakProfile, VerifyFunction } from '../../types';
 
 export const KeycloakStrategy = require('@exlinc/keycloak-passport');
 
 export interface KeycloakStrategyFactory {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (options: any): typeof KeycloakStrategy;
+  (options: any, verifierPassed?: VerifyFunction.KeycloakAuthFn): typeof KeycloakStrategy;
 }
 
 export class KeycloakStrategyFactoryProvider
@@ -18,14 +18,15 @@ export class KeycloakStrategyFactoryProvider
   constructor(
     @inject(Strategies.Passport.KEYCLOAK_VERIFIER)
     private readonly verifierKeycloak: VerifyFunction.KeycloakAuthFn,
-  ) {}
+  ) { }
 
   value(): KeycloakStrategyFactory {
-    return (options) => this.getKeycloakAuthStrategyVerifier(options);
+    return (options, verifier) => this.getKeycloakAuthStrategyVerifier(options, verifier);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getKeycloakAuthStrategyVerifier(options: any): typeof KeycloakStrategy {
+  getKeycloakAuthStrategyVerifier(options: any, verifierPassed?: VerifyFunction.KeycloakAuthFn): typeof KeycloakStrategy {
+    const verifyFn = verifierPassed ?? this.verifierKeycloak;
     return new KeycloakStrategy(
       options,
       async (
@@ -35,7 +36,7 @@ export class KeycloakStrategyFactoryProvider
         cb: (err?: string | Error, user?: IAuthUser) => void,
       ) => {
         try {
-          const user = await this.verifierKeycloak(
+          const user = await verifyFn(
             accessToken,
             refreshToken,
             profile,

--- a/src/strategies/passport/passport-local/local-password-strategy-factory-provider.ts
+++ b/src/strategies/passport/passport-local/local-password-strategy-factory-provider.ts
@@ -1,18 +1,19 @@
-import {inject, Provider} from '@loopback/core';
-import {HttpErrors, Request} from '@loopback/rest';
+import { inject, Provider } from '@loopback/core';
+import { HttpErrors, Request } from '@loopback/rest';
 import * as PassportLocal from 'passport-local';
 
-import {AuthErrorKeys} from '../../../error-keys';
-import {IAuthUser} from '../../../types';
-import {Strategies} from '../../keys';
-import {VerifyFunction} from '../../types';
-import {isEmpty} from 'lodash';
+import { AuthErrorKeys } from '../../../error-keys';
+import { IAuthUser } from '../../../types';
+import { Strategies } from '../../keys';
+import { VerifyFunction } from '../../types';
+import { isEmpty } from 'lodash';
 
 export interface LocalPasswordStrategyFactory {
   (
     options?:
       | PassportLocal.IStrategyOptions
       | PassportLocal.IStrategyOptionsWithRequest,
+    verifierPassed?: VerifyFunction.LocalPasswordFn
   ): PassportLocal.Strategy;
 }
 
@@ -21,17 +22,19 @@ export class LocalPasswordStrategyFactoryProvider
   constructor(
     @inject(Strategies.Passport.LOCAL_PASSWORD_VERIFIER)
     private readonly verifierLocal: VerifyFunction.LocalPasswordFn,
-  ) {}
+  ) { }
 
   value(): LocalPasswordStrategyFactory {
-    return (options) => this.getLocalStrategyVerifier(options);
+    return (options, verifier) => this.getLocalStrategyVerifier(options, verifier);
   }
 
   getLocalStrategyVerifier(
     options?:
       | PassportLocal.IStrategyOptions
       | PassportLocal.IStrategyOptionsWithRequest,
+    verifierPassed?: VerifyFunction.LocalPasswordFn
   ): PassportLocal.Strategy {
+    const verifyFn = verifierPassed ?? this.verifierLocal;
     if (options?.passReqToCallback) {
       return new PassportLocal.Strategy(
         options,
@@ -43,7 +46,7 @@ export class LocalPasswordStrategyFactoryProvider
           cb: (err: Error | null, user?: IAuthUser | false) => void,
         ) => {
           try {
-            const user = await this.verifierLocal(username, password, req);
+            const user = await verifyFn(username, password, req);
             if (!user) {
               throw new HttpErrors.Unauthorized(
                 AuthErrorKeys.InvalidCredentials,
@@ -65,7 +68,7 @@ export class LocalPasswordStrategyFactoryProvider
           cb: (err: Error | null, user?: IAuthUser | false) => void,
         ) => {
           try {
-            const user = await this.verifierLocal(username, password);
+            const user = await verifyFn(username, password);
             if (!user) {
               throw new HttpErrors.Unauthorized(
                 AuthErrorKeys.InvalidCredentials,
@@ -86,7 +89,7 @@ export class LocalPasswordStrategyFactoryProvider
           cb: (err: Error | null, user?: IAuthUser | false) => void,
         ) => {
           try {
-            const user = await this.verifierLocal(
+            const user = await verifyFn(
               username,
               password,
               undefined,

--- a/src/strategies/passport/passport-local/local-password-strategy-factory-provider.ts
+++ b/src/strategies/passport/passport-local/local-password-strategy-factory-provider.ts
@@ -1,19 +1,19 @@
-import { inject, Provider } from '@loopback/core';
-import { HttpErrors, Request } from '@loopback/rest';
+import {inject, Provider} from '@loopback/core';
+import {HttpErrors, Request} from '@loopback/rest';
 import * as PassportLocal from 'passport-local';
 
-import { AuthErrorKeys } from '../../../error-keys';
-import { IAuthUser } from '../../../types';
-import { Strategies } from '../../keys';
-import { VerifyFunction } from '../../types';
-import { isEmpty } from 'lodash';
+import {AuthErrorKeys} from '../../../error-keys';
+import {IAuthUser} from '../../../types';
+import {Strategies} from '../../keys';
+import {VerifyFunction} from '../../types';
+import {isEmpty} from 'lodash';
 
 export interface LocalPasswordStrategyFactory {
   (
     options?:
       | PassportLocal.IStrategyOptions
       | PassportLocal.IStrategyOptionsWithRequest,
-    verifierPassed?: VerifyFunction.LocalPasswordFn
+    verifierPassed?: VerifyFunction.LocalPasswordFn,
   ): PassportLocal.Strategy;
 }
 
@@ -22,17 +22,18 @@ export class LocalPasswordStrategyFactoryProvider
   constructor(
     @inject(Strategies.Passport.LOCAL_PASSWORD_VERIFIER)
     private readonly verifierLocal: VerifyFunction.LocalPasswordFn,
-  ) { }
+  ) {}
 
   value(): LocalPasswordStrategyFactory {
-    return (options, verifier) => this.getLocalStrategyVerifier(options, verifier);
+    return (options, verifier) =>
+      this.getLocalStrategyVerifier(options, verifier);
   }
 
   getLocalStrategyVerifier(
     options?:
       | PassportLocal.IStrategyOptions
       | PassportLocal.IStrategyOptionsWithRequest,
-    verifierPassed?: VerifyFunction.LocalPasswordFn
+    verifierPassed?: VerifyFunction.LocalPasswordFn,
   ): PassportLocal.Strategy {
     const verifyFn = verifierPassed ?? this.verifierLocal;
     if (options?.passReqToCallback) {
@@ -89,11 +90,7 @@ export class LocalPasswordStrategyFactoryProvider
           cb: (err: Error | null, user?: IAuthUser | false) => void,
         ) => {
           try {
-            const user = await verifyFn(
-              username,
-              password,
-              undefined,
-            );
+            const user = await verifyFn(username, password, undefined);
             if (!user) {
               throw new HttpErrors.Unauthorized(
                 AuthErrorKeys.InvalidCredentials,

--- a/src/strategies/passport/passport-local/local-password-verify.provider.ts
+++ b/src/strategies/passport/passport-local/local-password-verify.provider.ts
@@ -13,7 +13,7 @@ export class LocalPasswordVerifyProvider
   constructor() {}
 
   value(): VerifyFunction.LocalPasswordFn {
-    return async (username, password) => {
+    return async (username: string, password: string) => {
       throw new HttpErrors.NotImplemented(
         `VerifyFunction.LocalPasswordFn is not implemented`,
       );

--- a/src/strategies/passport/passport-resource-owner-password/resource-owner-strategy-factory-provider.ts
+++ b/src/strategies/passport/passport-resource-owner-password/resource-owner-strategy-factory-provider.ts
@@ -1,16 +1,17 @@
-import {inject, Provider} from '@loopback/core';
-import {HttpErrors, Request} from '@loopback/rest';
+import { inject, Provider } from '@loopback/core';
+import { HttpErrors, Request } from '@loopback/rest';
 
-import {AuthErrorKeys} from '../../../error-keys';
-import {IAuthClient, IAuthUser} from '../../../types';
-import {Strategies} from '../../keys';
-import {VerifyFunction} from '../../types';
-import {Oauth2ResourceOwnerPassword} from './oauth2-resource-owner-password-grant';
-import {isEmpty} from 'lodash';
+import { AuthErrorKeys } from '../../../error-keys';
+import { IAuthClient, IAuthUser } from '../../../types';
+import { Strategies } from '../../keys';
+import { VerifyFunction } from '../../types';
+import { Oauth2ResourceOwnerPassword } from './oauth2-resource-owner-password-grant';
+import { isEmpty } from 'lodash';
 
 export interface ResourceOwnerPasswordStrategyFactory {
   (
     options?: Oauth2ResourceOwnerPassword.StrategyOptionsWithRequestInterface,
+    verifierPassed?: VerifyFunction.ResourceOwnerPasswordFn
   ): Oauth2ResourceOwnerPassword.Strategy;
 }
 
@@ -19,15 +20,17 @@ export class ResourceOwnerPasswordStrategyFactoryProvider
   constructor(
     @inject(Strategies.Passport.RESOURCE_OWNER_PASSWORD_VERIFIER)
     private readonly verifierResourceOwner: VerifyFunction.ResourceOwnerPasswordFn,
-  ) {}
+  ) { }
 
   value(): ResourceOwnerPasswordStrategyFactory {
-    return (options) => this.getResourceOwnerVerifier(options);
+    return (options, verifier) => this.getResourceOwnerVerifier(options, verifier);
   }
 
   getResourceOwnerVerifier(
     options?: Oauth2ResourceOwnerPassword.StrategyOptionsWithRequestInterface,
+    verifierPassed?: VerifyFunction.ResourceOwnerPasswordFn
   ): Oauth2ResourceOwnerPassword.Strategy {
+    const verifyFn = verifierPassed ?? this.verifierResourceOwner;
     if (options?.passReqToCallback) {
       return new Oauth2ResourceOwnerPassword.Strategy(
         options,
@@ -45,7 +48,7 @@ export class ResourceOwnerPasswordStrategyFactoryProvider
           ) => void,
         ) => {
           try {
-            const userInfo = await this.verifierResourceOwner(
+            const userInfo = await verifyFn(
               clientId,
               clientSecret,
               username,
@@ -78,7 +81,7 @@ export class ResourceOwnerPasswordStrategyFactoryProvider
           ) => void,
         ) => {
           try {
-            const userInfo = await this.verifierResourceOwner(
+            const userInfo = await verifyFn(
               clientId,
               clientSecret,
               username,

--- a/src/strategies/passport/passport-resource-owner-password/resource-owner-strategy-factory-provider.ts
+++ b/src/strategies/passport/passport-resource-owner-password/resource-owner-strategy-factory-provider.ts
@@ -1,17 +1,17 @@
-import { inject, Provider } from '@loopback/core';
-import { HttpErrors, Request } from '@loopback/rest';
+import {inject, Provider} from '@loopback/core';
+import {HttpErrors, Request} from '@loopback/rest';
 
-import { AuthErrorKeys } from '../../../error-keys';
-import { IAuthClient, IAuthUser } from '../../../types';
-import { Strategies } from '../../keys';
-import { VerifyFunction } from '../../types';
-import { Oauth2ResourceOwnerPassword } from './oauth2-resource-owner-password-grant';
-import { isEmpty } from 'lodash';
+import {AuthErrorKeys} from '../../../error-keys';
+import {IAuthClient, IAuthUser} from '../../../types';
+import {Strategies} from '../../keys';
+import {VerifyFunction} from '../../types';
+import {Oauth2ResourceOwnerPassword} from './oauth2-resource-owner-password-grant';
+import {isEmpty} from 'lodash';
 
 export interface ResourceOwnerPasswordStrategyFactory {
   (
     options?: Oauth2ResourceOwnerPassword.StrategyOptionsWithRequestInterface,
-    verifierPassed?: VerifyFunction.ResourceOwnerPasswordFn
+    verifierPassed?: VerifyFunction.ResourceOwnerPasswordFn,
   ): Oauth2ResourceOwnerPassword.Strategy;
 }
 
@@ -20,15 +20,16 @@ export class ResourceOwnerPasswordStrategyFactoryProvider
   constructor(
     @inject(Strategies.Passport.RESOURCE_OWNER_PASSWORD_VERIFIER)
     private readonly verifierResourceOwner: VerifyFunction.ResourceOwnerPasswordFn,
-  ) { }
+  ) {}
 
   value(): ResourceOwnerPasswordStrategyFactory {
-    return (options, verifier) => this.getResourceOwnerVerifier(options, verifier);
+    return (options, verifier) =>
+      this.getResourceOwnerVerifier(options, verifier);
   }
 
   getResourceOwnerVerifier(
     options?: Oauth2ResourceOwnerPassword.StrategyOptionsWithRequestInterface,
-    verifierPassed?: VerifyFunction.ResourceOwnerPasswordFn
+    verifierPassed?: VerifyFunction.ResourceOwnerPasswordFn,
   ): Oauth2ResourceOwnerPassword.Strategy {
     const verifyFn = verifierPassed ?? this.verifierResourceOwner;
     if (options?.passReqToCallback) {

--- a/src/strategies/types.ts
+++ b/src/strategies/types.ts
@@ -1,65 +1,71 @@
-import {Request} from '@loopback/rest';
+import { Request } from '@loopback/rest';
 import * as GoogleStrategy from 'passport-google-oauth20';
 import * as AzureADStrategy from 'passport-azure-ad';
 
-import {IAuthClient, IAuthUser} from '../types';
+import { IAuthClient, IAuthUser } from '../types';
 
 export namespace VerifyFunction {
-  export interface OauthClientPasswordFn {
+  export interface OauthClientPasswordFn<T = IAuthClient> {
     (
       clientId: string,
       clientSecret: string,
       req?: Request,
-    ): Promise<IAuthClient | null>;
+    ): Promise<T | null>;
   }
 
-  export interface LocalPasswordFn {
+  export interface LocalPasswordFn<T = IAuthUser> {
     (
       username: string,
       password: string,
       req?: Request,
-    ): Promise<IAuthUser | null>;
+    ): Promise<T | null>;
   }
 
-  export interface BearerFn {
-    (token: string, req?: Request): Promise<IAuthUser | null>;
+  export interface BearerFn<T = IAuthUser> {
+    (token: string, req?: Request): Promise<T | null>;
   }
 
-  export interface ResourceOwnerPasswordFn {
+  export interface ResourceOwnerPasswordFn<T = IAuthClient, S = IAuthUser> {
     (
       clientId: string,
       clientSecret: string,
       username: string,
       password: string,
       req?: Request,
-    ): Promise<{client: IAuthClient; user: IAuthUser} | null>;
+    ): Promise<{ client: T; user: S } | null>;
   }
 
-  export interface GoogleAuthFn {
+  export interface GoogleAuthFn<T = IAuthUser> {
     (
       accessToken: string,
       refreshToken: string,
       profile: GoogleStrategy.Profile,
       cb: GoogleStrategy.VerifyCallback,
       req?: Request,
-    ): Promise<IAuthUser | null>;
+    ): Promise<T | null>;
   }
 
-  export interface AzureADAuthFn {
+  export interface AzureADAuthFn<T = IAuthUser> {
     (
       profile: AzureADStrategy.IProfile,
       done: AzureADStrategy.VerifyCallback,
       req?: Request,
-    ): Promise<IAuthUser | null>;
+    ): Promise<T | null>;
   }
 
-  export interface KeycloakAuthFn {
+  export interface KeycloakAuthFn<T = IAuthUser> {
     (
       accessToken: string,
       refreshToken: string,
       profile: KeycloakProfile,
       cb: (err?: string | Error, user?: IAuthUser) => void,
-    ): Promise<IAuthUser | null>;
+    ): Promise<T | null>;
+  }
+
+  export interface GenericAuthFn<T = any> {
+    (
+      ...params: any
+    ): Promise<T>;
   }
 }
 

--- a/src/strategies/types.ts
+++ b/src/strategies/types.ts
@@ -5,19 +5,21 @@ import * as AzureADStrategy from 'passport-azure-ad';
 import {IAuthClient, IAuthUser} from '../types';
 
 export namespace VerifyFunction {
-  export interface OauthClientPasswordFn<T = IAuthClient> {
+  export interface OauthClientPasswordFn<T = IAuthClient>
+    extends GenericAuthFn<T> {
     (clientId: string, clientSecret: string, req?: Request): Promise<T | null>;
   }
 
-  export interface LocalPasswordFn<T = IAuthUser> {
+  export interface LocalPasswordFn<T = IAuthUser> extends GenericAuthFn<T> {
     (username: string, password: string, req?: Request): Promise<T | null>;
   }
 
-  export interface BearerFn<T = IAuthUser> {
+  export interface BearerFn<T = IAuthUser> extends GenericAuthFn<T> {
     (token: string, req?: Request): Promise<T | null>;
   }
 
-  export interface ResourceOwnerPasswordFn<T = IAuthClient, S = IAuthUser> {
+  export interface ResourceOwnerPasswordFn<T = IAuthClient, S = IAuthUser>
+    extends GenericAuthFn<T> {
     (
       clientId: string,
       clientSecret: string,
@@ -27,7 +29,7 @@ export namespace VerifyFunction {
     ): Promise<{client: T; user: S} | null>;
   }
 
-  export interface GoogleAuthFn<T = IAuthUser> {
+  export interface GoogleAuthFn<T = IAuthUser> extends GenericAuthFn<T> {
     (
       accessToken: string,
       refreshToken: string,
@@ -37,7 +39,7 @@ export namespace VerifyFunction {
     ): Promise<T | null>;
   }
 
-  export interface AzureADAuthFn<T = IAuthUser> {
+  export interface AzureADAuthFn<T = IAuthUser> extends GenericAuthFn<T> {
     (
       profile: AzureADStrategy.IProfile,
       done: AzureADStrategy.VerifyCallback,
@@ -45,7 +47,7 @@ export namespace VerifyFunction {
     ): Promise<T | null>;
   }
 
-  export interface KeycloakAuthFn<T = IAuthUser> {
+  export interface KeycloakAuthFn<T = IAuthUser> extends GenericAuthFn<T> {
     (
       accessToken: string,
       refreshToken: string,

--- a/src/strategies/types.ts
+++ b/src/strategies/types.ts
@@ -18,8 +18,7 @@ export namespace VerifyFunction {
     (token: string, req?: Request): Promise<T | null>;
   }
 
-  export interface ResourceOwnerPasswordFn<T = IAuthClient, S = IAuthUser>
-    extends GenericAuthFn<T> {
+  export interface ResourceOwnerPasswordFn<T = IAuthClient, S = IAuthUser> {
     (
       clientId: string,
       clientSecret: string,
@@ -59,7 +58,7 @@ export namespace VerifyFunction {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   export interface GenericAuthFn<T = any> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (...params: any): Promise<T>;
+    (...params: any): Promise<T | null>;
   }
 }
 

--- a/src/strategies/types.ts
+++ b/src/strategies/types.ts
@@ -1,24 +1,16 @@
-import { Request } from '@loopback/rest';
+import {Request} from '@loopback/rest';
 import * as GoogleStrategy from 'passport-google-oauth20';
 import * as AzureADStrategy from 'passport-azure-ad';
 
-import { IAuthClient, IAuthUser } from '../types';
+import {IAuthClient, IAuthUser} from '../types';
 
 export namespace VerifyFunction {
   export interface OauthClientPasswordFn<T = IAuthClient> {
-    (
-      clientId: string,
-      clientSecret: string,
-      req?: Request,
-    ): Promise<T | null>;
+    (clientId: string, clientSecret: string, req?: Request): Promise<T | null>;
   }
 
   export interface LocalPasswordFn<T = IAuthUser> {
-    (
-      username: string,
-      password: string,
-      req?: Request,
-    ): Promise<T | null>;
+    (username: string, password: string, req?: Request): Promise<T | null>;
   }
 
   export interface BearerFn<T = IAuthUser> {
@@ -32,7 +24,7 @@ export namespace VerifyFunction {
       username: string,
       password: string,
       req?: Request,
-    ): Promise<{ client: T; user: S } | null>;
+    ): Promise<{client: T; user: S} | null>;
   }
 
   export interface GoogleAuthFn<T = IAuthUser> {
@@ -62,10 +54,10 @@ export namespace VerifyFunction {
     ): Promise<T | null>;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   export interface GenericAuthFn<T = any> {
-    (
-      ...params: any
-    ): Promise<T>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (...params: any): Promise<T>;
   }
 }
 

--- a/src/strategies/user-auth-strategy.provider.ts
+++ b/src/strategies/user-auth-strategy.provider.ts
@@ -44,6 +44,7 @@ export class AuthStrategyProvider implements Provider<Strategy | undefined> {
       return undefined;
     }
 
+    //check if custom verifier binding is provided in the metadata
     let verifier;
     if (this.metadata.verifier) {
       verifier = await this.ctx.get(this.metadata.verifier);

--- a/src/strategies/user-auth-strategy.provider.ts
+++ b/src/strategies/user-auth-strategy.provider.ts
@@ -1,23 +1,24 @@
-import {inject, Provider, ValueOrPromise} from '@loopback/context';
-import {Strategy} from 'passport';
+import { inject, Provider, ValueOrPromise } from '@loopback/context';
+import { Strategy } from 'passport';
 import * as GoogleStrategy from 'passport-google-oauth20';
 import * as AzureADAuthStrategy from 'passport-azure-ad';
 import * as PassportBearer from 'passport-http-bearer';
 import * as PassportLocal from 'passport-local';
 
-import {AuthenticationBindings} from '../keys';
-import {STRATEGY} from '../strategy-name.enum';
-import {AuthenticationMetadata} from '../types';
-import {Strategies} from './keys';
-import {BearerStrategyFactory} from './passport/passport-bearer';
-import {GoogleAuthStrategyFactory} from './passport/passport-google-oauth2';
-import {LocalPasswordStrategyFactory} from './passport/passport-local';
+import { AuthenticationBindings } from '../keys';
+import { STRATEGY } from '../strategy-name.enum';
+import { AuthenticationMetadata } from '../types';
+import { Strategies } from './keys';
+import { BearerStrategyFactory } from './passport/passport-bearer';
+import { GoogleAuthStrategyFactory } from './passport/passport-google-oauth2';
+import { LocalPasswordStrategyFactory } from './passport/passport-local';
 import {
   Oauth2ResourceOwnerPassword,
   ResourceOwnerPasswordStrategyFactory,
 } from './passport/passport-resource-owner-password';
-import {AzureADAuthStrategyFactory} from './passport/passport-azure-ad';
-import {KeycloakStrategyFactory} from './passport';
+import { AzureADAuthStrategyFactory } from './passport/passport-azure-ad';
+import { KeycloakStrategyFactory } from './passport';
+import { Context } from 'vm';
 
 export class AuthStrategyProvider implements Provider<Strategy | undefined> {
   constructor(
@@ -35,43 +36,55 @@ export class AuthStrategyProvider implements Provider<Strategy | undefined> {
     private readonly getAzureADAuthVerifier: AzureADAuthStrategyFactory,
     @inject(Strategies.Passport.KEYCLOAK_STRATEGY_FACTORY)
     private readonly getKeycloakVerifier: KeycloakStrategyFactory,
-  ) {}
+    @inject.context() private readonly ctx: Context
+  ) { }
 
-  value(): ValueOrPromise<Strategy | undefined> {
+  async value(): Promise<Strategy | undefined> {
     if (!this.metadata) {
       return undefined;
+    }
+
+
+    let verifier;
+    if (this.metadata.verifier) {
+      verifier = await this.ctx.get(this.metadata.verifier);
     }
 
     const name = this.metadata.strategy;
     if (name === STRATEGY.LOCAL) {
       return this.getLocalStrategyVerifier(
         this.metadata.options as
-          | PassportLocal.IStrategyOptions
-          | PassportLocal.IStrategyOptionsWithRequest,
+        | PassportLocal.IStrategyOptions
+        | PassportLocal.IStrategyOptionsWithRequest,
+        verifier
       );
     } else if (name === STRATEGY.BEARER) {
       return this.getBearerStrategyVerifier(
         this.metadata.options as PassportBearer.IStrategyOptions,
+        verifier
       );
     } else if (name === STRATEGY.OAUTH2_RESOURCE_OWNER_GRANT) {
       return this.getResourceOwnerVerifier(
         this.metadata
           .options as Oauth2ResourceOwnerPassword.StrategyOptionsWithRequestInterface,
+        verifier
       );
     } else if (name === STRATEGY.GOOGLE_OAUTH2) {
       return this.getGoogleAuthVerifier(
         this.metadata.options as
-          | GoogleStrategy.StrategyOptions
-          | GoogleStrategy.StrategyOptionsWithRequest,
+        | GoogleStrategy.StrategyOptions
+        | GoogleStrategy.StrategyOptionsWithRequest,
+        verifier
       );
     } else if (name === STRATEGY.AZURE_AD) {
       return this.getAzureADAuthVerifier(
         this.metadata.options as
-          | AzureADAuthStrategy.IOIDCStrategyOptionWithRequest
-          | AzureADAuthStrategy.IOIDCStrategyOptionWithoutRequest,
+        | AzureADAuthStrategy.IOIDCStrategyOptionWithRequest
+        | AzureADAuthStrategy.IOIDCStrategyOptionWithoutRequest,
+        verifier
       );
     } else if (name === STRATEGY.KEYCLOAK) {
-      return this.getKeycloakVerifier(this.metadata.options);
+      return this.getKeycloakVerifier(this.metadata.options, verifier);
     } else {
       return Promise.reject(`The strategy ${name} is not available.`);
     }

--- a/src/strategies/user-auth-strategy.provider.ts
+++ b/src/strategies/user-auth-strategy.provider.ts
@@ -1,4 +1,4 @@
-import {inject, Provider} from '@loopback/context';
+import {Context, inject, Provider} from '@loopback/core';
 import {Strategy} from 'passport';
 import * as GoogleStrategy from 'passport-google-oauth20';
 import * as AzureADAuthStrategy from 'passport-azure-ad';
@@ -18,7 +18,7 @@ import {
 } from './passport/passport-resource-owner-password';
 import {AzureADAuthStrategyFactory} from './passport/passport-azure-ad';
 import {KeycloakStrategyFactory} from './passport';
-import {Context} from 'vm';
+import {VerifyFunction} from './types';
 
 export class AuthStrategyProvider implements Provider<Strategy | undefined> {
   constructor(
@@ -47,7 +47,9 @@ export class AuthStrategyProvider implements Provider<Strategy | undefined> {
     //check if custom verifier binding is provided in the metadata
     let verifier;
     if (this.metadata.verifier) {
-      verifier = await this.ctx.get(this.metadata.verifier);
+      verifier = await this.ctx.get<VerifyFunction.GenericAuthFn>(
+        this.metadata.verifier,
+      );
     }
 
     const name = this.metadata.strategy;
@@ -56,35 +58,38 @@ export class AuthStrategyProvider implements Provider<Strategy | undefined> {
         this.metadata.options as
           | PassportLocal.IStrategyOptions
           | PassportLocal.IStrategyOptionsWithRequest,
-        verifier,
+        verifier as VerifyFunction.LocalPasswordFn,
       );
     } else if (name === STRATEGY.BEARER) {
       return this.getBearerStrategyVerifier(
         this.metadata.options as PassportBearer.IStrategyOptions,
-        verifier,
+        verifier as VerifyFunction.BearerFn,
       );
     } else if (name === STRATEGY.OAUTH2_RESOURCE_OWNER_GRANT) {
       return this.getResourceOwnerVerifier(
         this.metadata
           .options as Oauth2ResourceOwnerPassword.StrategyOptionsWithRequestInterface,
-        verifier,
+        verifier as VerifyFunction.ResourceOwnerPasswordFn,
       );
     } else if (name === STRATEGY.GOOGLE_OAUTH2) {
       return this.getGoogleAuthVerifier(
         this.metadata.options as
           | GoogleStrategy.StrategyOptions
           | GoogleStrategy.StrategyOptionsWithRequest,
-        verifier,
+        verifier as VerifyFunction.GoogleAuthFn,
       );
     } else if (name === STRATEGY.AZURE_AD) {
       return this.getAzureADAuthVerifier(
         this.metadata.options as
           | AzureADAuthStrategy.IOIDCStrategyOptionWithRequest
           | AzureADAuthStrategy.IOIDCStrategyOptionWithoutRequest,
-        verifier,
+        verifier as VerifyFunction.AzureADAuthFn,
       );
     } else if (name === STRATEGY.KEYCLOAK) {
-      return this.getKeycloakVerifier(this.metadata.options, verifier);
+      return this.getKeycloakVerifier(
+        this.metadata.options,
+        verifier as VerifyFunction.KeycloakAuthFn,
+      );
     } else {
       return Promise.reject(`The strategy ${name} is not available.`);
     }

--- a/src/strategies/user-auth-strategy.provider.ts
+++ b/src/strategies/user-auth-strategy.provider.ts
@@ -1,24 +1,24 @@
-import { inject, Provider, ValueOrPromise } from '@loopback/context';
-import { Strategy } from 'passport';
+import {inject, Provider} from '@loopback/context';
+import {Strategy} from 'passport';
 import * as GoogleStrategy from 'passport-google-oauth20';
 import * as AzureADAuthStrategy from 'passport-azure-ad';
 import * as PassportBearer from 'passport-http-bearer';
 import * as PassportLocal from 'passport-local';
 
-import { AuthenticationBindings } from '../keys';
-import { STRATEGY } from '../strategy-name.enum';
-import { AuthenticationMetadata } from '../types';
-import { Strategies } from './keys';
-import { BearerStrategyFactory } from './passport/passport-bearer';
-import { GoogleAuthStrategyFactory } from './passport/passport-google-oauth2';
-import { LocalPasswordStrategyFactory } from './passport/passport-local';
+import {AuthenticationBindings} from '../keys';
+import {STRATEGY} from '../strategy-name.enum';
+import {AuthenticationMetadata} from '../types';
+import {Strategies} from './keys';
+import {BearerStrategyFactory} from './passport/passport-bearer';
+import {GoogleAuthStrategyFactory} from './passport/passport-google-oauth2';
+import {LocalPasswordStrategyFactory} from './passport/passport-local';
 import {
   Oauth2ResourceOwnerPassword,
   ResourceOwnerPasswordStrategyFactory,
 } from './passport/passport-resource-owner-password';
-import { AzureADAuthStrategyFactory } from './passport/passport-azure-ad';
-import { KeycloakStrategyFactory } from './passport';
-import { Context } from 'vm';
+import {AzureADAuthStrategyFactory} from './passport/passport-azure-ad';
+import {KeycloakStrategyFactory} from './passport';
+import {Context} from 'vm';
 
 export class AuthStrategyProvider implements Provider<Strategy | undefined> {
   constructor(
@@ -36,14 +36,13 @@ export class AuthStrategyProvider implements Provider<Strategy | undefined> {
     private readonly getAzureADAuthVerifier: AzureADAuthStrategyFactory,
     @inject(Strategies.Passport.KEYCLOAK_STRATEGY_FACTORY)
     private readonly getKeycloakVerifier: KeycloakStrategyFactory,
-    @inject.context() private readonly ctx: Context
-  ) { }
+    @inject.context() private readonly ctx: Context,
+  ) {}
 
   async value(): Promise<Strategy | undefined> {
     if (!this.metadata) {
       return undefined;
     }
-
 
     let verifier;
     if (this.metadata.verifier) {
@@ -54,34 +53,34 @@ export class AuthStrategyProvider implements Provider<Strategy | undefined> {
     if (name === STRATEGY.LOCAL) {
       return this.getLocalStrategyVerifier(
         this.metadata.options as
-        | PassportLocal.IStrategyOptions
-        | PassportLocal.IStrategyOptionsWithRequest,
-        verifier
+          | PassportLocal.IStrategyOptions
+          | PassportLocal.IStrategyOptionsWithRequest,
+        verifier,
       );
     } else if (name === STRATEGY.BEARER) {
       return this.getBearerStrategyVerifier(
         this.metadata.options as PassportBearer.IStrategyOptions,
-        verifier
+        verifier,
       );
     } else if (name === STRATEGY.OAUTH2_RESOURCE_OWNER_GRANT) {
       return this.getResourceOwnerVerifier(
         this.metadata
           .options as Oauth2ResourceOwnerPassword.StrategyOptionsWithRequestInterface,
-        verifier
+        verifier,
       );
     } else if (name === STRATEGY.GOOGLE_OAUTH2) {
       return this.getGoogleAuthVerifier(
         this.metadata.options as
-        | GoogleStrategy.StrategyOptions
-        | GoogleStrategy.StrategyOptionsWithRequest,
-        verifier
+          | GoogleStrategy.StrategyOptions
+          | GoogleStrategy.StrategyOptionsWithRequest,
+        verifier,
       );
     } else if (name === STRATEGY.AZURE_AD) {
       return this.getAzureADAuthVerifier(
         this.metadata.options as
-        | AzureADAuthStrategy.IOIDCStrategyOptionWithRequest
-        | AzureADAuthStrategy.IOIDCStrategyOptionWithoutRequest,
-        verifier
+          | AzureADAuthStrategy.IOIDCStrategyOptionWithRequest
+          | AzureADAuthStrategy.IOIDCStrategyOptionWithoutRequest,
+        verifier,
       );
     } else if (name === STRATEGY.KEYCLOAK) {
       return this.getKeycloakVerifier(this.metadata.options, verifier);

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import {Request, Response} from '@loopback/rest';
+import { BindingKey } from '@loopback/core';
+import { Request, Response } from '@loopback/rest';
+import { VerifyFunction } from './strategies';
 export * from './strategies/types';
 
 export interface IAuthClient {
@@ -18,9 +20,10 @@ export interface IAuthUser {
   password?: string;
 }
 
-export interface AuthenticationMetadata {
+export interface AuthenticationMetadata<T = void> {
   strategy: string;
   options?: Object;
+  verifier?: BindingKey<VerifyFunction.GenericAuthFn<T>>;
   authOptions?: (req: Request) => Object;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,9 +3,9 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-import { BindingKey } from '@loopback/core';
-import { Request, Response } from '@loopback/rest';
-import { VerifyFunction } from './strategies';
+import {BindingKey} from '@loopback/core';
+import {Request, Response} from '@loopback/rest';
+import {VerifyFunction} from './strategies';
 export * from './strategies/types';
 
 export interface IAuthClient {


### PR DESCRIPTION
## Description

Adds a facility to bind a custom verifier through provider binding key in the metadata of Authentication decorator.

For RPMS-3023

- [X] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] Performed a self-review of my own code
- [X] Code conforms with the style guide