### PR TITLE
AF-38: Binding bugfix for Instagram Oauth2

### DIFF
--- a/src/component.ts
+++ b/src/component.ts
@@ -18,6 +18,8 @@ import {
   ClientPasswordVerifyProvider,
   GoogleAuthStrategyFactoryProvider,
   GoogleAuthVerifyProvider,
+  InstagramAuthStrategyFactoryProvider,
+  InstagramAuthVerifyProvider,
   KeycloakStrategyFactoryProvider,
   KeycloakVerifyProvider,
   LocalPasswordStrategyFactoryProvider,
@@ -49,6 +51,8 @@ export class AuthenticationComponent implements Component {
         .key]: ResourceOwnerPasswordStrategyFactoryProvider,
       [Strategies.Passport.GOOGLE_OAUTH2_STRATEGY_FACTORY
         .key]: GoogleAuthStrategyFactoryProvider,
+      [Strategies.Passport.INSTAGRAM_OAUTH2_STRATEGY_FACTORY
+        .key]: InstagramAuthStrategyFactoryProvider,
       [Strategies.Passport.AZURE_AD_STRATEGY_FACTORY
         .key]: AzureADAuthStrategyFactoryProvider,
       [Strategies.Passport.KEYCLOAK_STRATEGY_FACTORY
@@ -65,6 +69,8 @@ export class AuthenticationComponent implements Component {
         .key]: ResourceOwnerVerifyProvider,
       [Strategies.Passport.GOOGLE_OAUTH2_VERIFIER
         .key]: GoogleAuthVerifyProvider,
+      [Strategies.Passport.INSTAGRAM_OAUTH2_VERIFIER
+        .key]: InstagramAuthVerifyProvider,
       [Strategies.Passport.AZURE_AD_VERIFIER.key]: AzureADAuthVerifyProvider,
       [Strategies.Passport.KEYCLOAK_VERIFIER.key]: KeycloakVerifyProvider,
     };

--- a/src/strategies/types.ts
+++ b/src/strategies/types.ts
@@ -7,6 +7,7 @@ import {IAuthClient, IAuthUser} from '../types';
 export type VerifyCallback = (
   err?: string | Error | null,
   user?: Express.User,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   info?: any,
 ) => void;
 


### PR DESCRIPTION
Fixed binding issue for instagram in component.
VerifyCallback interface for Instagram was not present in passport-instagram so created a local interface similar to google oauth VerifyCallback interface. But it has a field named info with 'any' datatype so it might give sonar cloud error.