### PR TITLE
fix profile object of keycloak to ensure all data is transferred back  to consumer

### DIFF
--- a/src/strategies/types.ts
+++ b/src/strategies/types.ts
@@ -89,4 +89,6 @@ export interface KeycloakProfile {
   email: string;
   avatar: string;
   realm: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
 }


### PR DESCRIPTION
This PR fixes #42 

Allowed all properties coming in response from userinfo endpoint of keycloak to move ahead. Earlier, only a fixed set of keys were parsed and sent back as profile object.
