### PR TITLE
fix(provider): adding tokens to verify type for azure

### DIFF
--- a/src/__tests__/fixtures/providers/azuread-auth.provider.ts
+++ b/src/__tests__/fixtures/providers/azuread-auth.provider.ts
@@ -11,6 +11,8 @@ export class BearerTokenVerifyProvider
 
   value(): VerifyFunction.AzureADAuthFn {
     return async (
+      accessToken: string,
+      refreshToken: string,
       profile: AzureADAuthStrategy.IProfile,
       done: AzureADAuthStrategy.VerifyCallback,
       req?: Request,

--- a/src/__tests__/unit/passport-azure-ad/azuread-auth-strategy.unit.ts
+++ b/src/__tests__/unit/passport-azure-ad/azuread-auth-strategy.unit.ts
@@ -70,7 +70,11 @@ async function getStrategy() {
 }
 
 //returning a user
-function verifierBearer(profile: IProfile): Promise<IAuthUser | null> {
+function verifierBearer(
+  accessToken: string,
+  refreshToken: string,
+  profile: IProfile,
+): Promise<IAuthUser | null> {
   const userToPass: IAuthUser = {
     id: 1,
     username: 'xyz',

--- a/src/strategies/passport/passport-azure-ad/azuread-auth-strategy-factory-provider.ts
+++ b/src/strategies/passport/passport-azure-ad/azuread-auth-strategy-factory-provider.ts
@@ -42,13 +42,27 @@ export class AzureADAuthStrategyFactoryProvider
         options,
 
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
-        async (req: Request, profile: IProfile, done: VerifyCallback) => {
+        async (
+          req: Request,
+          iss: string,
+          sub: string,
+          profile: IProfile,
+          accessToken: string,
+          refreshToken: string,
+          done: VerifyCallback,
+        ) => {
           if (!profile.oid) {
             return done(new Error('No oid found'), null);
           }
 
           try {
-            const user = await verifyFn(profile, done, req);
+            const user = await verifyFn(
+              accessToken,
+              refreshToken,
+              profile,
+              done,
+              req,
+            );
             if (!user) {
               throw new HttpErrors.Unauthorized(
                 AuthErrorKeys.InvalidCredentials,
@@ -65,13 +79,25 @@ export class AzureADAuthStrategyFactoryProvider
         options,
 
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
-        async (profile: IProfile, done: VerifyCallback) => {
+        async (
+          iss: string,
+          sub: string,
+          profile: IProfile,
+          accessToken: string,
+          refreshToken: string,
+          done: VerifyCallback,
+        ) => {
           if (!profile.oid) {
             return done(new Error('No oid found'), null);
           }
 
           try {
-            const user = await verifyFn(profile, done);
+            const user = await verifyFn(
+              accessToken,
+              refreshToken,
+              profile,
+              done,
+            );
             if (!user) {
               throw new HttpErrors.Unauthorized(
                 AuthErrorKeys.InvalidCredentials,

--- a/src/strategies/passport/passport-azure-ad/azuread-auth-verify.provider.ts
+++ b/src/strategies/passport/passport-azure-ad/azuread-auth-verify.provider.ts
@@ -16,6 +16,8 @@ export class AzureADAuthVerifyProvider
 
   value(): VerifyFunction.AzureADAuthFn {
     return async (
+      accessToken: string,
+      refreshToken: string,
       profile: AzureADStrategy.IProfile,
       done: AzureADStrategy.VerifyCallback,
       req?: Request,

--- a/src/strategies/types/types.ts
+++ b/src/strategies/types/types.ts
@@ -56,6 +56,8 @@ export namespace VerifyFunction {
 
   export interface AzureADAuthFn<T = IAuthUser> extends GenericAuthFn<T> {
     (
+      accessToken: string,
+      refreshToken: string,
       profile: AzureADStrategy.IProfile,
       done: AzureADStrategy.VerifyCallback,
       req?: Request,


### PR DESCRIPTION
BREAKING CHANGE:
changed the verify function signature

GH-91

## Description

The verifier type for Azure AD is not similar to other verifier functions.
The verifier type is missing access token and refresh token


Fixes #91

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)


## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
