### PR TITLE
feat(chore): remove support for node v14,v12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
         "typescript": "~4.9.5"
       },
       "engines": {
-        "node": "12 || 14 || 16 || 17"
+        "node": "16 || 17|| 18"
       },
       "peerDependencies": {
         "@loopback/boot": "^5.0.10",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "main": "index.js",
   "engines": {
-    "node": "12 || 14 || 16 || 17"
+    "node": "16 || 17 || 18"
   },
   "scripts": {
     "build": "npm run clean && lb-tsc",


### PR DESCRIPTION
## Description

- Both node v12 and node v14 have reached their end of life

- BREAKING CHANGE:- End of life of node v14 and node v12

GH-161


Fixes #161

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
