### PR TITLE
fix(component): make client password and bearer strategy as mandatory 

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -87,7 +87,6 @@ Once this is done, you are ready to configure any of the available strategy in t
 
 ### Oauth2-client-password
 
-In order to use it, run `npm install passport-oauth2-client-password`.
 First, create an AuthClient model implementing the IAuthClient interface. The purpose of this model is to store oauth registered clients for the app in the DB. See sample below.
 
 ```ts
@@ -250,7 +249,6 @@ For accessing the authenticated AuthClient model reference, you can inject the C
 
 ### Http-bearer
 
-In order to use it, run `npm install passport-http-bearer`.
 First, create a AuthUser model implementing the IAuthUser interface. You can implement the interface in the user model itself. See sample below.
 
 ```ts

--- a/package.json
+++ b/package.json
@@ -20,14 +20,6 @@
       "type": "./dist/strategies/passport/passport-azure-ad/index.d.ts",
       "default": "./dist/strategies/passport/passport-azure-ad/index.js"
     },
-    "./passport-bearer": {
-      "type": "./dist/strategies/passport/passport-bearer/index.d.ts",
-      "default": "./dist/strategies/passport/passport-bearer/index.js"
-    },
-    "./passport-client-password": {
-      "type": "./dist/strategies/passport/passport-client-password/index.d.ts",
-      "default": "./dist/strategies/passport/passport-client-password/index.js"
-    },
     "./passport-cognito-oauth2": {
       "type": "./dist/strategies/passport/passport-cognito-oauth2/index.d.ts",
       "default": "./dist/strategies/passport/passport-cognito-oauth2/index.js"
@@ -157,6 +149,8 @@
     "https-proxy-agent": "^5.0.0",
     "jsonwebtoken": "^9.0.0",
     "passport": "^0.6.0",
+    "passport-http-bearer": "^1.0.1",
+    "passport-oauth2-client-password": "^0.1.2",
     "tslib": "^2.0.0"
   },
   "devDependencies": {
@@ -208,11 +202,9 @@
     "passport-cognito-oauth2": "^0.1.1",
     "passport-facebook": "^3.0.0",
     "passport-google-oauth20": "^2.0.0",
-    "passport-http-bearer": "^1.0.1",
     "passport-instagram": "^1.0.0",
     "passport-local": "^1.0.0",
     "passport-oauth2": "^1.6.1",
-    "passport-oauth2-client-password": "^0.1.2",
     "@exlinc/keycloak-passport": "^1.0.2"
   },
   "publishConfig": {

--- a/src/__tests__/integration/action-sequence/passport-apple-oauth2/apple-oauth2.integration.ts
+++ b/src/__tests__/integration/action-sequence/passport-apple-oauth2/apple-oauth2.integration.ts
@@ -1,18 +1,16 @@
-import {Client, createClientForHandler} from '@loopback/testlab';
-import {RestServer, Request} from '@loopback/rest';
-import {Application, Constructor, Provider} from '@loopback/core';
+import {Application, Provider} from '@loopback/core';
 import {get} from '@loopback/openapi-v3';
-import {authenticate} from '../../../../decorators';
-import {STRATEGY} from '../../../../strategy-name.enum';
-import {getApp} from '../helpers/helpers';
-import {MyAuthenticationSequence} from '../../../fixtures/sequences/authentication.sequence';
-import {Strategies} from '../../../../strategies/keys';
-import {VerifyFunction} from '../../../../strategies';
-import {userWithoutReqObj} from '../../../fixtures/data/bearer-data';
+import {Request, RestServer} from '@loopback/rest';
+import {Client, createClientForHandler} from '@loopback/testlab';
 import AppleStrategy, {DecodedIdToken} from 'passport-apple';
+import {authenticate} from '../../../../decorators';
+import {VerifyFunction} from '../../../../strategies';
+import {Strategies} from '../../../../strategies/keys';
 import {AppleAuthStrategyFactoryProvider} from '../../../../strategies/passport/passport-apple-oauth2';
-import {ClientPasswordVerifyProvider} from '../../../fixtures/providers/passport-client.provider';
-import {ClientPasswordStrategyFactoryProvider} from '../../../../strategies/passport/passport-client-password';
+import {STRATEGY} from '../../../../strategy-name.enum';
+import {userWithoutReqObj} from '../../../fixtures/data/bearer-data';
+import {MyAuthenticationSequence} from '../../../fixtures/sequences/authentication.sequence';
+import {getApp} from '../helpers/helpers';
 
 describe('getting apple oauth2 strategy with options', () => {
   let app: Application;
@@ -51,12 +49,6 @@ describe('getting apple oauth2 strategy with options', () => {
   }
 
   function getAuthVerifier() {
-    app
-      .bind(Strategies.Passport.OAUTH2_CLIENT_PASSWORD_VERIFIER)
-      .toProvider(ClientPasswordVerifyProvider);
-    app
-      .bind(Strategies.Passport.CLIENT_PASSWORD_STRATEGY_FACTORY)
-      .toProvider(ClientPasswordStrategyFactoryProvider);
     app
       .bind(Strategies.Passport.APPLE_OAUTH2_STRATEGY_FACTORY)
       .toProvider(AppleAuthStrategyFactoryProvider);

--- a/src/__tests__/integration/action-sequence/passport-bearer/bearer-token-verify.integration.ts
+++ b/src/__tests__/integration/action-sequence/passport-bearer/bearer-token-verify.integration.ts
@@ -1,18 +1,15 @@
-import {IAuthUser} from '../../../../types';
-import {expect, Client, createClientForHandler} from '@loopback/testlab';
-import {RestServer} from '@loopback/rest';
 import {Application, inject} from '@loopback/core';
 import {get} from '@loopback/openapi-v3';
+import {RestServer} from '@loopback/rest';
+import {Client, createClientForHandler, expect} from '@loopback/testlab';
 import {authenticate} from '../../../../decorators';
-import {STRATEGY} from '../../../../strategy-name.enum';
-import {getApp} from '../helpers/helpers';
-import {MyAuthenticationSequence} from '../../../fixtures/sequences/authentication.sequence';
-import {Strategies} from '../../../../strategies/keys';
 import {AuthenticationBindings} from '../../../../keys';
+import {Strategies} from '../../../../strategies/keys';
+import {STRATEGY} from '../../../../strategy-name.enum';
+import {IAuthUser} from '../../../../types';
 import {BearerTokenVerifyProvider} from '../../../fixtures/providers/bearer-passport.provider';
-import {BearerStrategyFactoryProvider} from '../../../../strategies/passport/passport-bearer';
-import {ClientPasswordVerifyProvider} from '../../../fixtures/providers/passport-client.provider';
-import {ClientPasswordStrategyFactoryProvider} from '../../../../strategies/passport/passport-client-password';
+import {MyAuthenticationSequence} from '../../../fixtures/sequences/authentication.sequence';
+import {getApp} from '../helpers/helpers';
 
 /**
  * Testing overall flow of authentication with bearer strategy
@@ -242,15 +239,53 @@ describe('Bearer-token strategy', () => {
     app
       .bind(Strategies.Passport.BEARER_TOKEN_VERIFIER)
       .toProvider(BearerTokenVerifyProvider);
-    app
-      .bind(Strategies.Passport.BEARER_STRATEGY_FACTORY)
-      .toProvider(BearerStrategyFactoryProvider);
-    app
-      .bind(Strategies.Passport.OAUTH2_CLIENT_PASSWORD_VERIFIER)
-      .toProvider(ClientPasswordVerifyProvider);
-    app
-      .bind(Strategies.Passport.CLIENT_PASSWORD_STRATEGY_FACTORY)
-      .toProvider(ClientPasswordStrategyFactoryProvider);
+  }
+
+  function givenAuthenticatedSequence() {
+    // bind user defined sequence
+    server.sequence(MyAuthenticationSequence);
+  }
+});
+
+describe('integration test when no provider was implemented', () => {
+  let app: Application;
+  let server: RestServer;
+  beforeEach(givenAServer);
+  beforeEach(givenAuthenticatedSequence);
+
+  it('should return error as the verifier is not implemented', async () => {
+    class BearerNoVerifierController {
+      constructor(
+        @inject(AuthenticationBindings.CURRENT_USER) // tslint:disable-next-line: no-shadowed-variable
+        private readonly user: IAuthUser | undefined,
+      ) {}
+
+      options = {
+        passRequestToCallback: false,
+      };
+
+      @get('/auth/bearer/no-verifier')
+      @authenticate(STRATEGY.BEARER, {passReqToCallback: false})
+      async test() {
+        return this.user;
+      }
+    }
+
+    app.controller(BearerNoVerifierController);
+
+    await whenIMakeRequestTo(server)
+      .get('/auth/bearer/no-verifier')
+      .set('Authorization', 'Bearer sometoken')
+      .expect(401);
+  });
+
+  function whenIMakeRequestTo(restServer: RestServer): Client {
+    return createClientForHandler(restServer.requestHandler);
+  }
+
+  async function givenAServer() {
+    app = getApp();
+    server = await app.getServer(RestServer);
   }
 
   function givenAuthenticatedSequence() {

--- a/src/__tests__/integration/action-sequence/passport-client-password/client-password-verify.integration.ts
+++ b/src/__tests__/integration/action-sequence/passport-client-password/client-password-verify.integration.ts
@@ -1,18 +1,17 @@
 /* eslint-disable  @typescript-eslint/naming-convention */
 
-import {IAuthClient} from '../../../../types';
-import {Client, createClientForHandler, expect} from '@loopback/testlab';
-import {RestServer} from '@loopback/rest';
 import {Application, inject} from '@loopback/core';
 import {post, requestBody} from '@loopback/openapi-v3';
+import {RestServer} from '@loopback/rest';
+import {Client, createClientForHandler, expect} from '@loopback/testlab';
 import {authenticateClient} from '../../../../decorators';
-import {STRATEGY} from '../../../../strategy-name.enum';
-import {getApp} from '../helpers/helpers';
-import {MyAuthenticationSequence} from '../../../fixtures/sequences/authentication.sequence';
-import {Strategies} from '../../../../strategies/keys';
 import {AuthenticationBindings} from '../../../../keys';
+import {Strategies} from '../../../../strategies/keys';
+import {STRATEGY} from '../../../../strategy-name.enum';
+import {IAuthClient} from '../../../../types';
 import {ClientPasswordVerifyProvider} from '../../../fixtures/providers/passport-client.provider';
-import {ClientPasswordStrategyFactoryProvider} from '../../../../strategies/passport/passport-client-password';
+import {MyAuthenticationSequence} from '../../../fixtures/sequences/authentication.sequence';
+import {getApp} from '../helpers/helpers';
 
 describe('Client-password strategy', () => {
   let app: Application;
@@ -144,9 +143,55 @@ describe('Client-password strategy', () => {
     app
       .bind(Strategies.Passport.OAUTH2_CLIENT_PASSWORD_VERIFIER)
       .toProvider(ClientPasswordVerifyProvider);
-    app
-      .bind(Strategies.Passport.CLIENT_PASSWORD_STRATEGY_FACTORY)
-      .toProvider(ClientPasswordStrategyFactoryProvider);
+  }
+
+  function givenAuthenticatedSequence() {
+    // bind user defined sequence
+    server.sequence(MyAuthenticationSequence);
+  }
+});
+
+describe('integration test for client-password and no verifier', () => {
+  let app: Application;
+  let server: RestServer;
+  beforeEach(givenAServer);
+  beforeEach(givenAuthenticatedSequence);
+
+  it('should return status 401 as this strategy is not implemented', async () => {
+    class TestController {
+      constructor(
+        @inject(AuthenticationBindings.CURRENT_CLIENT) // tslint:disable-next-line: no-shadowed-variable
+        private readonly client: IAuthClient | undefined,
+      ) {}
+
+      @post('/test')
+      @authenticateClient(STRATEGY.CLIENT_PASSWORD, {passReqToCallback: true})
+      test(
+        @requestBody()
+        body: {
+          client_id: string;
+          client_secret: string;
+        },
+      ) {
+        return this.client;
+      }
+    }
+
+    app.controller(TestController);
+
+    await whenIMakeRequestTo(server)
+      .post('/test')
+      .send({client_id: 'some id', client_secret: 'some secret'})
+      .expect(401);
+  });
+
+  function whenIMakeRequestTo(restServer: RestServer): Client {
+    return createClientForHandler(restServer.requestHandler);
+  }
+
+  async function givenAServer() {
+    app = getApp();
+    server = await app.getServer(RestServer);
   }
 
   function givenAuthenticatedSequence() {

--- a/src/__tests__/integration/action-sequence/passport-cognito-oauth2/cognito-oauth2.integration.ts
+++ b/src/__tests__/integration/action-sequence/passport-cognito-oauth2/cognito-oauth2.integration.ts
@@ -1,18 +1,16 @@
-import {Client, createClientForHandler} from '@loopback/testlab';
-import {RestServer, Request} from '@loopback/rest';
-import {Application, Constructor, Provider} from '@loopback/core';
+import {Application, Provider} from '@loopback/core';
 import {get} from '@loopback/openapi-v3';
+import {Request, RestServer} from '@loopback/rest';
+import {Client, createClientForHandler} from '@loopback/testlab';
 import {authenticate} from '../../../../decorators';
-import {STRATEGY} from '../../../../strategy-name.enum';
-import {getApp} from '../helpers/helpers';
-import {MyAuthenticationSequence} from '../../../fixtures/sequences/authentication.sequence';
-import {Strategies} from '../../../../strategies/keys';
 import {VerifyFunction} from '../../../../strategies';
-import {userWithoutReqObj} from '../../../fixtures/data/bearer-data';
-import {Cognito} from '../../../../types';
+import {Strategies} from '../../../../strategies/keys';
 import {CognitoStrategyFactoryProvider} from '../../../../strategies/passport/passport-cognito-oauth2';
-import {ClientPasswordVerifyProvider} from '../../../fixtures/providers/passport-client.provider';
-import {ClientPasswordStrategyFactoryProvider} from '../../../../strategies/passport/passport-client-password';
+import {STRATEGY} from '../../../../strategy-name.enum';
+import {Cognito} from '../../../../types';
+import {userWithoutReqObj} from '../../../fixtures/data/bearer-data';
+import {MyAuthenticationSequence} from '../../../fixtures/sequences/authentication.sequence';
+import {getApp} from '../helpers/helpers';
 
 describe('getting cognito oauth2 strategy with options', () => {
   let app: Application;
@@ -49,12 +47,6 @@ describe('getting cognito oauth2 strategy with options', () => {
   }
 
   function getAuthVerifier() {
-    app
-      .bind(Strategies.Passport.OAUTH2_CLIENT_PASSWORD_VERIFIER)
-      .toProvider(ClientPasswordVerifyProvider);
-    app
-      .bind(Strategies.Passport.CLIENT_PASSWORD_STRATEGY_FACTORY)
-      .toProvider(ClientPasswordStrategyFactoryProvider);
     app
       .bind(Strategies.Passport.COGNITO_OAUTH2_VERIFIER)
       .toProvider(CognitoAuthVerifyProvider);

--- a/src/__tests__/integration/action-sequence/passport-google-oauth2/google-oauth2.integration.ts
+++ b/src/__tests__/integration/action-sequence/passport-google-oauth2/google-oauth2.integration.ts
@@ -1,18 +1,16 @@
-import {Client, createClientForHandler} from '@loopback/testlab';
-import {RestServer, Request} from '@loopback/rest';
-import {Application, Constructor, Provider} from '@loopback/core';
+import {Application, Provider} from '@loopback/core';
 import {get} from '@loopback/openapi-v3';
-import {authenticate} from '../../../../decorators';
-import {STRATEGY} from '../../../../strategy-name.enum';
-import {getApp} from '../helpers/helpers';
-import {MyAuthenticationSequence} from '../../../fixtures/sequences/authentication.sequence';
-import {Strategies} from '../../../../strategies/keys';
-import {VerifyFunction} from '../../../../strategies';
-import {userWithoutReqObj} from '../../../fixtures/data/bearer-data';
+import {Request, RestServer} from '@loopback/rest';
+import {Client, createClientForHandler} from '@loopback/testlab';
 import * as GoogleStrategy from 'passport-google-oauth20';
+import {authenticate} from '../../../../decorators';
+import {VerifyFunction} from '../../../../strategies';
+import {Strategies} from '../../../../strategies/keys';
 import {GoogleAuthStrategyFactoryProvider} from '../../../../strategies/passport/passport-google-oauth2';
-import {ClientPasswordVerifyProvider} from '../../../fixtures/providers/passport-client.provider';
-import {ClientPasswordStrategyFactoryProvider} from '../../../../strategies/passport/passport-client-password';
+import {STRATEGY} from '../../../../strategy-name.enum';
+import {userWithoutReqObj} from '../../../fixtures/data/bearer-data';
+import {MyAuthenticationSequence} from '../../../fixtures/sequences/authentication.sequence';
+import {getApp} from '../helpers/helpers';
 
 describe('getting google oauth2 strategy with options', () => {
   let app: Application;
@@ -49,12 +47,6 @@ describe('getting google oauth2 strategy with options', () => {
   }
 
   function getAuthVerifier() {
-    app
-      .bind(Strategies.Passport.OAUTH2_CLIENT_PASSWORD_VERIFIER)
-      .toProvider(ClientPasswordVerifyProvider);
-    app
-      .bind(Strategies.Passport.CLIENT_PASSWORD_STRATEGY_FACTORY)
-      .toProvider(ClientPasswordStrategyFactoryProvider);
     app
       .bind(Strategies.Passport.GOOGLE_OAUTH2_VERIFIER)
       .toProvider(GoogleAuthVerifyProvider);

--- a/src/__tests__/integration/action-sequence/passport-instagram-oauth2/instagram-oauth2.integration.ts
+++ b/src/__tests__/integration/action-sequence/passport-instagram-oauth2/instagram-oauth2.integration.ts
@@ -1,18 +1,16 @@
-import {Client, createClientForHandler} from '@loopback/testlab';
-import {RestServer, Request} from '@loopback/rest';
-import {Application, Constructor, Provider} from '@loopback/core';
+import {Application, Provider} from '@loopback/core';
 import {get} from '@loopback/openapi-v3';
-import {authenticate} from '../../../../decorators';
-import {STRATEGY} from '../../../../strategy-name.enum';
-import {getApp} from '../helpers/helpers';
-import {MyAuthenticationSequence} from '../../../fixtures/sequences/authentication.sequence';
-import {Strategies} from '../../../../strategies/keys';
-import {VerifyCallback, VerifyFunction} from '../../../../strategies';
-import {userWithoutReqObj} from '../../../fixtures/data/bearer-data';
+import {Request, RestServer} from '@loopback/rest';
+import {Client, createClientForHandler} from '@loopback/testlab';
 import * as InstagramStrategy from 'passport-instagram';
+import {authenticate} from '../../../../decorators';
+import {VerifyCallback, VerifyFunction} from '../../../../strategies';
+import {Strategies} from '../../../../strategies/keys';
 import {InstagramAuthStrategyFactoryProvider} from '../../../../strategies/passport/passport-insta-oauth2';
-import {ClientPasswordVerifyProvider} from '../../../fixtures/providers/passport-client.provider';
-import {ClientPasswordStrategyFactoryProvider} from '../../../../strategies/passport/passport-client-password';
+import {STRATEGY} from '../../../../strategy-name.enum';
+import {userWithoutReqObj} from '../../../fixtures/data/bearer-data';
+import {MyAuthenticationSequence} from '../../../fixtures/sequences/authentication.sequence';
+import {getApp} from '../helpers/helpers';
 
 describe('getting instagram oauth2 strategy with options', () => {
   let app: Application;
@@ -49,12 +47,6 @@ describe('getting instagram oauth2 strategy with options', () => {
   }
 
   function getAuthVerifier() {
-    app
-      .bind(Strategies.Passport.OAUTH2_CLIENT_PASSWORD_VERIFIER)
-      .toProvider(ClientPasswordVerifyProvider);
-    app
-      .bind(Strategies.Passport.CLIENT_PASSWORD_STRATEGY_FACTORY)
-      .toProvider(ClientPasswordStrategyFactoryProvider);
     app
       .bind(Strategies.Passport.INSTAGRAM_OAUTH2_STRATEGY_FACTORY)
       .toProvider(InstagramAuthStrategyFactoryProvider);

--- a/src/__tests__/integration/action-sequence/passport-keycloak/keycloak.integration.ts
+++ b/src/__tests__/integration/action-sequence/passport-keycloak/keycloak.integration.ts
@@ -1,18 +1,16 @@
-import {Client, createClientForHandler} from '@loopback/testlab';
-import {RestServer, Request} from '@loopback/rest';
-import {Application, Constructor, Provider} from '@loopback/core';
+import {Application, Provider} from '@loopback/core';
 import {get} from '@loopback/openapi-v3';
+import {Request, RestServer} from '@loopback/rest';
+import {Client, createClientForHandler} from '@loopback/testlab';
 import {authenticate} from '../../../../decorators';
-import {STRATEGY} from '../../../../strategy-name.enum';
-import {getApp} from '../helpers/helpers';
-import {MyAuthenticationSequence} from '../../../fixtures/sequences/authentication.sequence';
-import {Strategies} from '../../../../strategies/keys';
 import {Keycloak, VerifyFunction} from '../../../../strategies';
-import {userWithoutReqObj} from '../../../fixtures/data/bearer-data';
-import {IAuthUser} from '../../../../types';
+import {Strategies} from '../../../../strategies/keys';
 import {KeycloakStrategyFactoryProvider} from '../../../../strategies/passport/passport-keycloak';
-import {ClientPasswordVerifyProvider} from '../../../fixtures/providers/passport-client.provider';
-import {ClientPasswordStrategyFactoryProvider} from '../../../../strategies/passport/passport-client-password';
+import {STRATEGY} from '../../../../strategy-name.enum';
+import {IAuthUser} from '../../../../types';
+import {userWithoutReqObj} from '../../../fixtures/data/bearer-data';
+import {MyAuthenticationSequence} from '../../../fixtures/sequences/authentication.sequence';
+import {getApp} from '../helpers/helpers';
 
 describe('getting keycloak oauth2 strategy with options', () => {
   let app: Application;
@@ -55,12 +53,6 @@ describe('getting keycloak oauth2 strategy with options', () => {
   }
 
   function getAuthVerifier() {
-    app
-      .bind(Strategies.Passport.OAUTH2_CLIENT_PASSWORD_VERIFIER)
-      .toProvider(ClientPasswordVerifyProvider);
-    app
-      .bind(Strategies.Passport.CLIENT_PASSWORD_STRATEGY_FACTORY)
-      .toProvider(ClientPasswordStrategyFactoryProvider);
     app
       .bind(Strategies.Passport.KEYCLOAK_VERIFIER)
       .toProvider(KeycloakAuthVerifyProvider);

--- a/src/__tests__/integration/action-sequence/passport-local/local-passport.integration.ts
+++ b/src/__tests__/integration/action-sequence/passport-local/local-passport.integration.ts
@@ -1,19 +1,17 @@
-import {Client, createClientForHandler, expect} from '@loopback/testlab';
-import {RestServer} from '@loopback/rest';
 import {Application, inject} from '@loopback/core';
 import {post, requestBody} from '@loopback/openapi-v3';
+import {RestServer} from '@loopback/rest';
+import {Client, createClientForHandler, expect} from '@loopback/testlab';
 import {authenticate} from '../../../../decorators';
-import {STRATEGY} from '../../../../strategy-name.enum';
-import {getApp} from '../helpers/helpers';
-import {MyAuthenticationSequence} from '../../../fixtures/sequences/authentication.sequence';
-import {Strategies} from '../../../../strategies/keys';
-import {LocalVerifyProvider} from '../../../fixtures/providers/local-password.provider';
 import {AuthenticationBindings} from '../../../../keys';
-import {IAuthUser} from '../../../../types';
-import {UserCred} from '../../../fixtures/user-cred.model';
+import {Strategies} from '../../../../strategies/keys';
 import {LocalPasswordStrategyFactoryProvider} from '../../../../strategies/passport/passport-local';
-import {ClientPasswordStrategyFactoryProvider} from '../../../../strategies/passport/passport-client-password';
-import {ClientPasswordVerifyProvider} from '../../../fixtures/providers/passport-client.provider';
+import {STRATEGY} from '../../../../strategy-name.enum';
+import {IAuthUser} from '../../../../types';
+import {LocalVerifyProvider} from '../../../fixtures/providers/local-password.provider';
+import {MyAuthenticationSequence} from '../../../fixtures/sequences/authentication.sequence';
+import {UserCred} from '../../../fixtures/user-cred.model';
+import {getApp} from '../helpers/helpers';
 /**
  * Testing overall flow of authentication with bearer strategy
  */
@@ -179,12 +177,6 @@ describe('Local passport strategy', () => {
     app
       .bind(Strategies.Passport.LOCAL_STRATEGY_FACTORY)
       .toProvider(LocalPasswordStrategyFactoryProvider);
-    app
-      .bind(Strategies.Passport.OAUTH2_CLIENT_PASSWORD_VERIFIER)
-      .toProvider(ClientPasswordVerifyProvider);
-    app
-      .bind(Strategies.Passport.CLIENT_PASSWORD_STRATEGY_FACTORY)
-      .toProvider(ClientPasswordStrategyFactoryProvider);
   }
 
   function givenAuthenticatedSequence() {

--- a/src/__tests__/integration/action-sequence/passport-resource-owner-password/resource-owner-password.integration.ts
+++ b/src/__tests__/integration/action-sequence/passport-resource-owner-password/resource-owner-password.integration.ts
@@ -1,20 +1,18 @@
 /* eslint-disable  @typescript-eslint/naming-convention */
 
-import {Client, createClientForHandler, expect} from '@loopback/testlab';
-import {RestServer} from '@loopback/rest';
 import {Application, inject} from '@loopback/core';
 import {post, requestBody} from '@loopback/openapi-v3';
+import {RestServer} from '@loopback/rest';
+import {Client, createClientForHandler, expect} from '@loopback/testlab';
 import {authenticate} from '../../../../decorators';
-import {STRATEGY} from '../../../../strategy-name.enum';
-import {getApp} from '../helpers/helpers';
-import {MyAuthenticationSequence} from '../../../fixtures/sequences/authentication.sequence';
-import {Strategies} from '../../../../strategies/keys';
-import {ResourceOwnerVerifyProvider} from '../../../fixtures/providers/resource-owner.provider';
 import {AuthenticationBindings} from '../../../../keys';
-import {IAuthUser} from '../../../../types';
+import {Strategies} from '../../../../strategies/keys';
 import {ResourceOwnerPasswordStrategyFactoryProvider} from '../../../../strategies/passport/passport-resource-owner-password';
-import {ClientPasswordVerifyProvider} from '../../../fixtures/providers/passport-client.provider';
-import {ClientPasswordStrategyFactoryProvider} from '../../../../strategies/passport/passport-client-password';
+import {STRATEGY} from '../../../../strategy-name.enum';
+import {IAuthUser} from '../../../../types';
+import {ResourceOwnerVerifyProvider} from '../../../fixtures/providers/resource-owner.provider';
+import {MyAuthenticationSequence} from '../../../fixtures/sequences/authentication.sequence';
+import {getApp} from '../helpers/helpers';
 
 describe('Resource-owner-password strategy', () => {
   let app: Application;
@@ -210,12 +208,6 @@ describe('Resource-owner-password strategy', () => {
     app
       .bind(Strategies.Passport.RESOURCE_OWNER_STRATEGY_FACTORY)
       .toProvider(ResourceOwnerPasswordStrategyFactoryProvider);
-    app
-      .bind(Strategies.Passport.OAUTH2_CLIENT_PASSWORD_VERIFIER)
-      .toProvider(ClientPasswordVerifyProvider);
-    app
-      .bind(Strategies.Passport.CLIENT_PASSWORD_STRATEGY_FACTORY)
-      .toProvider(ClientPasswordStrategyFactoryProvider);
   }
 
   function givenAuthenticatedSequence() {

--- a/src/__tests__/integration/middleware-sequence/passport-apple-oauth2/apple-oauth2.integration.ts
+++ b/src/__tests__/integration/middleware-sequence/passport-apple-oauth2/apple-oauth2.integration.ts
@@ -1,20 +1,16 @@
-import {Client, createClientForHandler} from '@loopback/testlab';
-import {RestServer, Request} from '@loopback/rest';
-import {Application, Constructor, Provider} from '@loopback/core';
+import {Application, Provider} from '@loopback/core';
 import {get} from '@loopback/openapi-v3';
-import {authenticate} from '../../../../decorators';
-import {STRATEGY} from '../../../../strategy-name.enum';
-import {getApp} from '../helpers/helpers';
-import {MyAuthenticationMiddlewareSequence} from '../../../fixtures/sequences/authentication-middleware.sequence';
-import {Strategies} from '../../../../strategies/keys';
-import {VerifyFunction} from '../../../../strategies';
-import {userWithoutReqObj} from '../../../fixtures/data/bearer-data';
+import {Request, RestServer} from '@loopback/rest';
+import {Client, createClientForHandler} from '@loopback/testlab';
 import AppleStrategy, {DecodedIdToken} from 'passport-apple';
+import {authenticate} from '../../../../decorators';
+import {VerifyFunction} from '../../../../strategies';
+import {Strategies} from '../../../../strategies/keys';
 import {AppleAuthStrategyFactoryProvider} from '../../../../strategies/passport/passport-apple-oauth2';
-import {
-  ClientPasswordStrategyFactoryProvider,
-  ClientPasswordVerifyProvider,
-} from '../../../../strategies/passport/passport-client-password';
+import {STRATEGY} from '../../../../strategy-name.enum';
+import {userWithoutReqObj} from '../../../fixtures/data/bearer-data';
+import {MyAuthenticationMiddlewareSequence} from '../../../fixtures/sequences/authentication-middleware.sequence';
+import {getApp} from '../helpers/helpers';
 
 describe('getting apple oauth2 strategy with options using Middleware Sequence', () => {
   let app: Application;
@@ -53,12 +49,6 @@ describe('getting apple oauth2 strategy with options using Middleware Sequence',
   }
 
   function getAuthVerifier() {
-    app
-      .bind(Strategies.Passport.OAUTH2_CLIENT_PASSWORD_VERIFIER)
-      .toProvider(ClientPasswordVerifyProvider);
-    app
-      .bind(Strategies.Passport.CLIENT_PASSWORD_STRATEGY_FACTORY)
-      .toProvider(ClientPasswordStrategyFactoryProvider);
     app
       .bind(Strategies.Passport.APPLE_OAUTH2_STRATEGY_FACTORY)
       .toProvider(AppleAuthStrategyFactoryProvider);

--- a/src/__tests__/integration/middleware-sequence/passport-client-password/client-password-verify.integration.ts
+++ b/src/__tests__/integration/middleware-sequence/passport-client-password/client-password-verify.integration.ts
@@ -1,18 +1,17 @@
 /* eslint-disable  @typescript-eslint/naming-convention */
 
-import {IAuthClient} from '../../../../types';
-import {Client, createClientForHandler, expect} from '@loopback/testlab';
-import {RestServer} from '@loopback/rest';
 import {Application, inject} from '@loopback/core';
 import {post, requestBody} from '@loopback/openapi-v3';
+import {RestServer} from '@loopback/rest';
+import {Client, createClientForHandler, expect} from '@loopback/testlab';
 import {authenticateClient} from '../../../../decorators';
-import {STRATEGY} from '../../../../strategy-name.enum';
-import {getApp} from '../helpers/helpers';
-import {MyAuthenticationMiddlewareSequence} from '../../../fixtures/sequences/authentication-middleware.sequence';
-import {Strategies} from '../../../../strategies/keys';
 import {AuthenticationBindings} from '../../../../keys';
+import {Strategies} from '../../../../strategies/keys';
+import {STRATEGY} from '../../../../strategy-name.enum';
+import {IAuthClient} from '../../../../types';
 import {ClientPasswordVerifyProvider} from '../../../fixtures/providers/passport-client.provider';
-import {ClientPasswordStrategyFactoryProvider} from '../../../../strategies/passport/passport-client-password';
+import {MyAuthenticationMiddlewareSequence} from '../../../fixtures/sequences/authentication-middleware.sequence';
+import {getApp} from '../helpers/helpers';
 
 describe('Client-password strategy using Middleware Sequence', () => {
   let app: Application;
@@ -142,11 +141,57 @@ describe('Client-password strategy using Middleware Sequence', () => {
 
   function getAuthVerifier() {
     app
-      .bind(Strategies.Passport.CLIENT_PASSWORD_STRATEGY_FACTORY)
-      .toProvider(ClientPasswordStrategyFactoryProvider);
-    app
       .bind(Strategies.Passport.OAUTH2_CLIENT_PASSWORD_VERIFIER)
       .toProvider(ClientPasswordVerifyProvider);
+  }
+
+  function givenAuthenticatedSequence() {
+    // bind user defined sequence
+    server.sequence(MyAuthenticationMiddlewareSequence);
+  }
+});
+
+describe('integration test for client-password and no verifier using Middleware Sequence', () => {
+  let app: Application;
+  let server: RestServer;
+  beforeEach(givenAServer);
+  beforeEach(givenAuthenticatedSequence);
+
+  it('should return status 401 as this strategy is not implemented', async () => {
+    class TestController {
+      constructor(
+        @inject(AuthenticationBindings.CURRENT_CLIENT) // tslint:disable-next-line: no-shadowed-variable
+        private readonly client: IAuthClient | undefined,
+      ) {}
+
+      @post('/test')
+      @authenticateClient(STRATEGY.CLIENT_PASSWORD, {passReqToCallback: true})
+      test(
+        @requestBody()
+        body: {
+          client_id: string;
+          client_secret: string;
+        },
+      ) {
+        return this.client;
+      }
+    }
+
+    app.controller(TestController);
+
+    await whenIMakeRequestTo(server)
+      .post('/test')
+      .send({client_id: 'some id', client_secret: 'some secret'})
+      .expect(401);
+  });
+
+  function whenIMakeRequestTo(restServer: RestServer): Client {
+    return createClientForHandler(restServer.requestHandler);
+  }
+
+  async function givenAServer() {
+    app = getApp();
+    server = await app.getServer(RestServer);
   }
 
   function givenAuthenticatedSequence() {

--- a/src/__tests__/integration/middleware-sequence/passport-cognito-oauth2/cognito-oauth2.integration.ts
+++ b/src/__tests__/integration/middleware-sequence/passport-cognito-oauth2/cognito-oauth2.integration.ts
@@ -1,18 +1,16 @@
-import {Client, createClientForHandler} from '@loopback/testlab';
-import {RestServer, Request} from '@loopback/rest';
-import {Application, Constructor, Provider} from '@loopback/core';
+import {Application, Provider} from '@loopback/core';
 import {get} from '@loopback/openapi-v3';
+import {Request, RestServer} from '@loopback/rest';
+import {Client, createClientForHandler} from '@loopback/testlab';
 import {authenticate} from '../../../../decorators';
-import {STRATEGY} from '../../../../strategy-name.enum';
-import {getApp} from '../helpers/helpers';
-import {Strategies} from '../../../../strategies/keys';
 import {VerifyFunction} from '../../../../strategies';
-import {userWithoutReqObj} from '../../../fixtures/data/bearer-data';
-import {Cognito} from '../../../../types';
-import {MyAuthenticationMiddlewareSequence} from '../../../fixtures/sequences/authentication-middleware.sequence';
+import {Strategies} from '../../../../strategies/keys';
 import {CognitoStrategyFactoryProvider} from '../../../../strategies/passport/passport-cognito-oauth2';
-import {ClientPasswordVerifyProvider} from '../../../fixtures/providers/passport-client.provider';
-import {ClientPasswordStrategyFactoryProvider} from '../../../../strategies/passport/passport-client-password';
+import {STRATEGY} from '../../../../strategy-name.enum';
+import {Cognito} from '../../../../types';
+import {userWithoutReqObj} from '../../../fixtures/data/bearer-data';
+import {MyAuthenticationMiddlewareSequence} from '../../../fixtures/sequences/authentication-middleware.sequence';
+import {getApp} from '../helpers/helpers';
 
 describe('getting cognito oauth2 strategy with options using Middleware Sequence', () => {
   let app: Application;
@@ -49,12 +47,6 @@ describe('getting cognito oauth2 strategy with options using Middleware Sequence
   }
 
   function getAuthVerifier() {
-    app
-      .bind(Strategies.Passport.OAUTH2_CLIENT_PASSWORD_VERIFIER)
-      .toProvider(ClientPasswordVerifyProvider);
-    app
-      .bind(Strategies.Passport.CLIENT_PASSWORD_STRATEGY_FACTORY)
-      .toProvider(ClientPasswordStrategyFactoryProvider);
     app
       .bind(Strategies.Passport.COGNITO_OAUTH2_VERIFIER)
       .toProvider(CognitoAuthVerifyProvider);

--- a/src/__tests__/integration/middleware-sequence/passport-google-oauth2/google-oauth2.integration.ts
+++ b/src/__tests__/integration/middleware-sequence/passport-google-oauth2/google-oauth2.integration.ts
@@ -1,18 +1,16 @@
-import {Client, createClientForHandler} from '@loopback/testlab';
-import {RestServer, Request} from '@loopback/rest';
-import {Application, Constructor, Provider} from '@loopback/core';
+import {Application, Provider} from '@loopback/core';
 import {get} from '@loopback/openapi-v3';
-import {authenticate} from '../../../../decorators';
-import {STRATEGY} from '../../../../strategy-name.enum';
-import {getApp} from '../helpers/helpers';
-import {MyAuthenticationMiddlewareSequence} from '../../../fixtures/sequences/authentication-middleware.sequence';
-import {Strategies} from '../../../../strategies/keys';
-import {VerifyFunction} from '../../../../strategies';
-import {userWithoutReqObj} from '../../../fixtures/data/bearer-data';
+import {Request, RestServer} from '@loopback/rest';
+import {Client, createClientForHandler} from '@loopback/testlab';
 import * as GoogleStrategy from 'passport-google-oauth20';
+import {authenticate} from '../../../../decorators';
+import {VerifyFunction} from '../../../../strategies';
+import {Strategies} from '../../../../strategies/keys';
 import {GoogleAuthStrategyFactoryProvider} from '../../../../strategies/passport/passport-google-oauth2';
-import {ClientPasswordVerifyProvider} from '../../../fixtures/providers/passport-client.provider';
-import {ClientPasswordStrategyFactoryProvider} from '../../../../strategies/passport/passport-client-password';
+import {STRATEGY} from '../../../../strategy-name.enum';
+import {userWithoutReqObj} from '../../../fixtures/data/bearer-data';
+import {MyAuthenticationMiddlewareSequence} from '../../../fixtures/sequences/authentication-middleware.sequence';
+import {getApp} from '../helpers/helpers';
 
 describe('getting google oauth2 strategy with options using Middleware Sequence', () => {
   let app: Application;
@@ -55,12 +53,6 @@ describe('getting google oauth2 strategy with options using Middleware Sequence'
     app
       .bind(Strategies.Passport.GOOGLE_OAUTH2_VERIFIER)
       .toProvider(GoogleAuthVerifyProvider);
-    app
-      .bind(Strategies.Passport.OAUTH2_CLIENT_PASSWORD_VERIFIER)
-      .toProvider(ClientPasswordVerifyProvider);
-    app
-      .bind(Strategies.Passport.CLIENT_PASSWORD_STRATEGY_FACTORY)
-      .toProvider(ClientPasswordStrategyFactoryProvider);
   }
 
   function givenAuthenticatedSequence() {

--- a/src/__tests__/integration/middleware-sequence/passport-instagram-oauth2/instagram-oauth2.integration.ts
+++ b/src/__tests__/integration/middleware-sequence/passport-instagram-oauth2/instagram-oauth2.integration.ts
@@ -1,18 +1,16 @@
-import {Client, createClientForHandler} from '@loopback/testlab';
-import {RestServer, Request} from '@loopback/rest';
-import {Application, Constructor, Provider} from '@loopback/core';
+import {Application, Provider} from '@loopback/core';
 import {get} from '@loopback/openapi-v3';
-import {authenticate} from '../../../../decorators';
-import {STRATEGY} from '../../../../strategy-name.enum';
-import {getApp} from '../helpers/helpers';
-import {MyAuthenticationMiddlewareSequence} from '../../../fixtures/sequences/authentication-middleware.sequence';
-import {Strategies} from '../../../../strategies/keys';
-import {VerifyCallback, VerifyFunction} from '../../../../strategies';
-import {userWithoutReqObj} from '../../../fixtures/data/bearer-data';
+import {Request, RestServer} from '@loopback/rest';
+import {Client, createClientForHandler} from '@loopback/testlab';
 import * as InstagramStrategy from 'passport-instagram';
+import {authenticate} from '../../../../decorators';
+import {VerifyCallback, VerifyFunction} from '../../../../strategies';
+import {Strategies} from '../../../../strategies/keys';
 import {InstagramAuthStrategyFactoryProvider} from '../../../../strategies/passport/passport-insta-oauth2';
-import {ClientPasswordVerifyProvider} from '../../../fixtures/providers/passport-client.provider';
-import {ClientPasswordStrategyFactoryProvider} from '../../../../strategies/passport/passport-client-password';
+import {STRATEGY} from '../../../../strategy-name.enum';
+import {userWithoutReqObj} from '../../../fixtures/data/bearer-data';
+import {MyAuthenticationMiddlewareSequence} from '../../../fixtures/sequences/authentication-middleware.sequence';
+import {getApp} from '../helpers/helpers';
 
 describe('getting instagram oauth2 strategy with options using Middleware Sequence', () => {
   let app: Application;
@@ -55,12 +53,6 @@ describe('getting instagram oauth2 strategy with options using Middleware Sequen
     app
       .bind(Strategies.Passport.INSTAGRAM_OAUTH2_VERIFIER)
       .toProvider(InstagramAuthVerifyProvider);
-    app
-      .bind(Strategies.Passport.OAUTH2_CLIENT_PASSWORD_VERIFIER)
-      .toProvider(ClientPasswordVerifyProvider);
-    app
-      .bind(Strategies.Passport.CLIENT_PASSWORD_STRATEGY_FACTORY)
-      .toProvider(ClientPasswordStrategyFactoryProvider);
   }
 
   function givenAuthenticatedSequence() {

--- a/src/__tests__/integration/middleware-sequence/passport-keycloak/keycloak.integration.ts
+++ b/src/__tests__/integration/middleware-sequence/passport-keycloak/keycloak.integration.ts
@@ -1,18 +1,16 @@
-import {Client, createClientForHandler} from '@loopback/testlab';
-import {RestServer, Request} from '@loopback/rest';
-import {Application, Constructor, Provider} from '@loopback/core';
+import {Application, Provider} from '@loopback/core';
 import {get} from '@loopback/openapi-v3';
+import {Request, RestServer} from '@loopback/rest';
+import {Client, createClientForHandler} from '@loopback/testlab';
 import {authenticate} from '../../../../decorators';
-import {STRATEGY} from '../../../../strategy-name.enum';
-import {getApp} from '../helpers/helpers';
-import {MyAuthenticationMiddlewareSequence} from '../../../fixtures/sequences/authentication-middleware.sequence';
-import {Strategies} from '../../../../strategies/keys';
 import {Keycloak, VerifyFunction} from '../../../../strategies';
-import {userWithoutReqObj} from '../../../fixtures/data/bearer-data';
-import {IAuthUser} from '../../../../types';
+import {Strategies} from '../../../../strategies/keys';
 import {KeycloakStrategyFactoryProvider} from '../../../../strategies/passport/passport-keycloak';
-import {ClientPasswordStrategyFactoryProvider} from '../../../../strategies/passport/passport-client-password';
-import {ClientPasswordVerifyProvider} from '../../../fixtures/providers/passport-client.provider';
+import {STRATEGY} from '../../../../strategy-name.enum';
+import {IAuthUser} from '../../../../types';
+import {userWithoutReqObj} from '../../../fixtures/data/bearer-data';
+import {MyAuthenticationMiddlewareSequence} from '../../../fixtures/sequences/authentication-middleware.sequence';
+import {getApp} from '../helpers/helpers';
 
 describe('getting keycloak oauth2 strategy with options using Middleware Sequence', () => {
   let app: Application;
@@ -61,12 +59,6 @@ describe('getting keycloak oauth2 strategy with options using Middleware Sequenc
     app
       .bind(Strategies.Passport.KEYCLOAK_VERIFIER)
       .toProvider(KeycloakAuthVerifyProvider);
-    app
-      .bind(Strategies.Passport.OAUTH2_CLIENT_PASSWORD_VERIFIER)
-      .toProvider(ClientPasswordVerifyProvider);
-    app
-      .bind(Strategies.Passport.CLIENT_PASSWORD_STRATEGY_FACTORY)
-      .toProvider(ClientPasswordStrategyFactoryProvider);
   }
 
   function givenAuthenticatedSequence() {

--- a/src/__tests__/integration/middleware-sequence/passport-local/local-passport.integration.ts
+++ b/src/__tests__/integration/middleware-sequence/passport-local/local-passport.integration.ts
@@ -1,19 +1,17 @@
-import {Client, createClientForHandler, expect} from '@loopback/testlab';
-import {RestServer} from '@loopback/rest';
 import {Application, inject} from '@loopback/core';
 import {post, requestBody} from '@loopback/openapi-v3';
+import {RestServer} from '@loopback/rest';
+import {Client, createClientForHandler, expect} from '@loopback/testlab';
 import {authenticate} from '../../../../decorators';
-import {STRATEGY} from '../../../../strategy-name.enum';
-import {getApp} from '../helpers/helpers';
-import {MyAuthenticationMiddlewareSequence} from '../../../fixtures/sequences/authentication-middleware.sequence';
-import {Strategies} from '../../../../strategies/keys';
-import {LocalVerifyProvider} from '../../../fixtures/providers/local-password.provider';
 import {AuthenticationBindings} from '../../../../keys';
-import {IAuthUser} from '../../../../types';
-import {UserCred} from '../../../fixtures/user-cred.model';
+import {Strategies} from '../../../../strategies/keys';
 import {LocalPasswordStrategyFactoryProvider} from '../../../../strategies/passport/passport-local';
-import {ClientPasswordVerifyProvider} from '../../../fixtures/providers/passport-client.provider';
-import {ClientPasswordStrategyFactoryProvider} from '../../../../strategies/passport/passport-client-password';
+import {STRATEGY} from '../../../../strategy-name.enum';
+import {IAuthUser} from '../../../../types';
+import {LocalVerifyProvider} from '../../../fixtures/providers/local-password.provider';
+import {MyAuthenticationMiddlewareSequence} from '../../../fixtures/sequences/authentication-middleware.sequence';
+import {UserCred} from '../../../fixtures/user-cred.model';
+import {getApp} from '../helpers/helpers';
 /**
  * Testing overall flow of authentication with bearer strategy
  */
@@ -179,12 +177,6 @@ describe('Local passport strategy using Middleware Sequence', () => {
     app
       .bind(Strategies.Passport.LOCAL_PASSWORD_VERIFIER)
       .toProvider(LocalVerifyProvider);
-    app
-      .bind(Strategies.Passport.OAUTH2_CLIENT_PASSWORD_VERIFIER)
-      .toProvider(ClientPasswordVerifyProvider);
-    app
-      .bind(Strategies.Passport.CLIENT_PASSWORD_STRATEGY_FACTORY)
-      .toProvider(ClientPasswordStrategyFactoryProvider);
   }
 
   function givenAuthenticatedSequence() {

--- a/src/__tests__/integration/middleware-sequence/passport-resource-owner-password/resource-owner-password.integration.ts
+++ b/src/__tests__/integration/middleware-sequence/passport-resource-owner-password/resource-owner-password.integration.ts
@@ -1,20 +1,18 @@
 /* eslint-disable  @typescript-eslint/naming-convention */
 
-import {Client, createClientForHandler, expect} from '@loopback/testlab';
-import {RestServer} from '@loopback/rest';
 import {Application, inject} from '@loopback/core';
 import {post, requestBody} from '@loopback/openapi-v3';
+import {RestServer} from '@loopback/rest';
+import {Client, createClientForHandler, expect} from '@loopback/testlab';
 import {authenticate} from '../../../../decorators';
-import {STRATEGY} from '../../../../strategy-name.enum';
-import {getApp} from '../helpers/helpers';
-import {MyAuthenticationMiddlewareSequence} from '../../../fixtures/sequences/authentication-middleware.sequence';
-import {Strategies} from '../../../../strategies/keys';
-import {ResourceOwnerVerifyProvider} from '../../../fixtures/providers/resource-owner.provider';
 import {AuthenticationBindings} from '../../../../keys';
-import {IAuthUser} from '../../../../types';
+import {Strategies} from '../../../../strategies/keys';
 import {ResourceOwnerPasswordStrategyFactoryProvider} from '../../../../strategies/passport/passport-resource-owner-password';
-import {ClientPasswordVerifyProvider} from '../../../fixtures/providers/passport-client.provider';
-import {ClientPasswordStrategyFactoryProvider} from '../../../../strategies/passport/passport-client-password';
+import {STRATEGY} from '../../../../strategy-name.enum';
+import {IAuthUser} from '../../../../types';
+import {ResourceOwnerVerifyProvider} from '../../../fixtures/providers/resource-owner.provider';
+import {MyAuthenticationMiddlewareSequence} from '../../../fixtures/sequences/authentication-middleware.sequence';
+import {getApp} from '../helpers/helpers';
 
 describe('Resource-owner-password strategy using Middleware Sequence', () => {
   let app: Application;
@@ -210,12 +208,6 @@ describe('Resource-owner-password strategy using Middleware Sequence', () => {
     app
       .bind(Strategies.Passport.RESOURCE_OWNER_PASSWORD_VERIFIER)
       .toProvider(ResourceOwnerVerifyProvider);
-    app
-      .bind(Strategies.Passport.OAUTH2_CLIENT_PASSWORD_VERIFIER)
-      .toProvider(ClientPasswordVerifyProvider);
-    app
-      .bind(Strategies.Passport.CLIENT_PASSWORD_STRATEGY_FACTORY)
-      .toProvider(ClientPasswordStrategyFactoryProvider);
   }
 
   function givenAuthenticatedSequence() {

--- a/src/component.ts
+++ b/src/component.ts
@@ -1,6 +1,5 @@
 import {Binding, Component, inject, ProviderMap} from '@loopback/core';
 import {createMiddlewareBinding} from '@loopback/express';
-
 import {AuthenticationBindings, Strategies} from './keys';
 import {
   ClientAuthenticationMiddlewareProvider,
@@ -12,7 +11,14 @@ import {
   ClientAuthenticateActionProvider,
   ClientAuthMetadataProvider,
 } from './providers';
-import {AuthStrategyProvider, ClientAuthStrategyProvider} from './strategies';
+import {
+  AuthStrategyProvider,
+  BearerStrategyFactoryProvider,
+  BearerTokenVerifyProvider,
+  ClientAuthStrategyProvider,
+  ClientPasswordStrategyFactoryProvider,
+  ClientPasswordVerifyProvider,
+} from './strategies';
 import {SecureClientPasswordStrategyFactoryProvider} from './strategies/passport/passport-client-password/secure-client-password-strategy-factory-provider';
 import {AuthenticationConfig} from './types';
 
@@ -29,6 +35,18 @@ export class AuthenticationComponent implements Component {
       [AuthenticationBindings.CLIENT_METADATA.key]: ClientAuthMetadataProvider,
       [AuthenticationBindings.USER_STRATEGY.key]: AuthStrategyProvider,
       [AuthenticationBindings.CLIENT_STRATEGY.key]: ClientAuthStrategyProvider,
+
+      // Strategy Function Factories
+      [Strategies.Passport.CLIENT_PASSWORD_STRATEGY_FACTORY.key]:
+        ClientPasswordStrategyFactoryProvider,
+      [Strategies.Passport.BEARER_STRATEGY_FACTORY.key]:
+        BearerStrategyFactoryProvider,
+
+      //  Strategy Verifier Functions
+      [Strategies.Passport.OAUTH2_CLIENT_PASSWORD_VERIFIER.key]:
+        ClientPasswordVerifyProvider,
+      [Strategies.Passport.BEARER_TOKEN_VERIFIER.key]:
+        BearerTokenVerifyProvider,
     };
 
     if (this.config?.secureClient) {

--- a/src/strategies/passport/index.ts
+++ b/src/strategies/passport/index.ts
@@ -1,1 +1,3 @@
 export * from './passport-otp';
+export * from './passport-bearer';
+export * from './passport-client-password';


### PR DESCRIPTION
make bearer strategy non optional,
resulting client password strategy also not optional

GH-209

## Description

Making the bearer strategy mandatory. But, by only making the bearer as manadatory, failed in test cases. Seems like, client password strategy is also needed for the same (infact all strategies as client is always needs to be authenticated first). So, I also made client password strategy as mandatory.

Fixes #209 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] Performed a self-review of my own code
- [x] npm test passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
