### PR TITLE
chore(ci-cd): changes to publish package via trusted oidc method

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ name: Release [Manual]
 on: workflow_dispatch
 permissions:
   contents: write
+  id-token: write   # required for trusted publishing
 jobs:
   Release:
     runs-on: ubuntu-latest
@@ -27,15 +28,15 @@ jobs:
           GITHUB_PAT: ${{ secrets.RELEASE_COMMIT_GH_PAT }}
           CONFIG_USERNAME: ${{ vars.RELEASE_COMMIT_USERNAME }}
           CONFIG_EMAIL: ${{ vars.RELEASE_COMMIT_EMAIL }}
-      - name: Authenticate with Registry
-        run: |
-          echo "@${NPM_USERNAME}:registry=https://registry.npmjs.org/" > .npmrc
-          echo "registry=https://registry.npmjs.org/" >> .npmrc
-          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
-          npm whoami
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_USERNAME: ${{ vars.NPM_USERNAME }}
+      # - name: Authenticate with Registry
+      #   run: |
+      #     echo "@${NPM_USERNAME}:registry=https://registry.npmjs.org/" > .npmrc
+      #     echo "registry=https://registry.npmjs.org/" >> .npmrc
+      #     echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
+      #     npm whoami
+      #   env:
+      #     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      #     NPM_USERNAME: ${{ vars.NPM_USERNAME }}
 
       - name: Install 📌
         run: |
@@ -44,9 +45,12 @@ jobs:
         run: npm run test
       - name: Semantic Publish to NPM 🚀
         # "HUSKY=0" disables pre-commit-msg check (Needed in order to allow semantic-release perform the release commit)
-        run: HUSKY=0 npx semantic-release
+        run: |
+          npm config set provenance true
+          HUSKY=0 npx semantic-release
         env:
           GH_TOKEN: ${{ secrets.RELEASE_COMMIT_GH_PAT }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # npm token not needed got trusted publishing
+          # NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Changelog 📝
         run: cd src/release_notes && HUSKY=0 node release-notes.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loopback4-authentication",
-  "version": "12.2.0",
+  "version": "13.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loopback4-authentication",
-      "version": "12.2.0",
+      "version": "13.0.0",
       "license": "MIT",
       "dependencies": {
         "@loopback/context": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "loopback4-authentication",
   "version": "13.0.0",
-  "description": "A loopback-next extension for authentication feature. Various Oauth strategies supported.",
+  "description": "A loopback-next extension for authentication feature. Various Oauth strategies supported by this package.",
   "keywords": [
     "loopback-extension",
     "loopback",


### PR DESCRIPTION
discontinue using tokens to publish

GH-269

## Description

changes to publish package via trusted oidc method
added id-token write access
removed registry authentication
removed npm token env for publishing

Fixes #269

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## Checklist:

- [ ] Performed a self-review of my own code
- [ ] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
